### PR TITLE
Styling of active file via Addin should ensure EOF line break.

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -30,7 +30,7 @@ style_active_file <- function() {
   }
   rstudioapi::modifyRange(
     c(1, 1, length(context$contents) + 1, 1),
-    paste0(out, collapse = "\n"), id = context$id
+    paste0(append(out, ""), collapse = "\n"), id = context$id
   )
   if (Sys.getenv("save_after_styling") == TRUE && context$path != "") {
     rstudioapi::documentSave(context$id)


### PR DESCRIPTION
Closes #310 . `enc::write_lines_enc(text, ...)` (which is used for `style_file()`, `style_pkg()` etc.) always adds an extra blank line at the end of `text` (no matter whether of not the last line is an empty line), while `rstudioapi::modifyRange()` (which is used for the two Addins of styling active file or style selection) does not. Hence, we need to add an extra blank line manually when `rstudioapi::modifyRange()` is used in the styling of the active file.