### PR TITLE
map_dfr() needs purrr 0.2.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Imports:
     cli,
     enc,
     magrittr,
-    purrr,
+    purrr (> 0.2.3),
     rematch2,
     rlang,
     rprojroot,


### PR DESCRIPTION
Closes #325. 