### PR TITLE
Use the dev version of enc package to fix handling non-ASCII characters on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,3 +66,5 @@ Collate:
     'vertical.R'
     'visit.R'
     'zzz.R'
+Remotes:
+    krlmlr/enc

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -1,11 +1,10 @@
 context("non-ASCII characters are handled properly")
 
 test_that("non-ASCII characters are handled properly", {
-  # c.f. rlang::mut_latin1_locale()
-  locale <- if (.Platform$OS.type == "windows") "English_United States.1252" else "en_US.ISO8859-1"
+  skip_if(.Platform$OS.type != "windows")
 
   withr::with_locale(
-    c(LC_CTYPE = locale),
+    c(LC_CTYPE = "English_United States.1252"),
     {
       tmp <- tempfile(fileext = ".R")
       con <- file(tmp, encoding = "UTF-8")

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -1,0 +1,23 @@
+context("non-ASCII characters are handled properly")
+
+test_that("non-ASCII characters are handled properly", {
+  # c.f. rlang::mut_latin1_locale()
+  locale <- if (.Platform$OS.type == "windows") "English_United States.1252" else "en_US.ISO8859-1"
+
+  withr::with_locale(
+    c(LC_CTYPE = locale),
+    {
+      # c.f. dplyr's tests/testthat/helper-encoding.R
+      latin_string <- "Gl\u00fcck+1"
+
+      tmp <- tempfile(fileext = ".R")
+      con <- file(tmp, encoding = "UTF-8")
+      on.exit(close(con), add = TRUE)
+
+      writeLines(latin_string, con)
+      style_file(tmp)
+      result <- readLines(con)
+      expect_equal(result, latin_string)
+    }
+  )
+})

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -7,17 +7,16 @@ test_that("non-ASCII characters are handled properly", {
   withr::with_locale(
     c(LC_CTYPE = locale),
     {
-      # c.f. dplyr's tests/testthat/helper-encoding.R
-      latin_string <- "Gl\u00fcck+1"
-
       tmp <- tempfile(fileext = ".R")
       con <- file(tmp, encoding = "UTF-8")
       on.exit(close(con), add = TRUE)
 
-      writeLines(latin_string, con)
+      # c.f. dplyr's tests/testthat/helper-encoding.R
+      writeLines("Gl\u00fcck+1", con)
+
       style_file(tmp)
       result <- readLines(con)
-      expect_equal(result, latin_string)
+      expect_equal(result, "Gl\u00fcck + 1")
     }
   )
 })


### PR DESCRIPTION
related: #329