### PR TITLE
type stability

### DIFF
--- a/R/style_guides.R
+++ b/R/style_guides.R
@@ -81,7 +81,7 @@ tidyverse_style <- function(scope = "tokens",
         math_token_spacing$one
       ),
       partial(
-        style_space_around_token, strict = strict, tokens = "'~'", level = 1),
+        style_space_around_token, strict = strict, tokens = "'~'", level = 1L),
       if (strict) set_space_around_op else add_space_around_op,
       if (strict) set_space_after_comma else add_space_after_comma,
       remove_space_after_opening_paren,

--- a/R/transform-files.R
+++ b/R/transform-files.R
@@ -156,9 +156,9 @@ apply_transformers <- function(pd_nested, transformers) {
 
   transformed_absolute_indent <- context_to_terminals(
     transformed_all,
-    outer_lag_newlines = 0,
-    outer_indent = 0,
-    outer_spaces = 0,
+    outer_lag_newlines = 0L,
+    outer_indent = 0L,
+    outer_spaces = 0L,
     outer_indention_refs = NA
   )
   transformed_absolute_indent


### PR DESCRIPTION
ensure int type for (lag) spaces / newlines to make code more efficient. No tests added because we could only test comprehensively within the styling (i.e. each time we style) and that's probably too much.