### PR TITLE
Spacing around EQ_FORMALS

### DIFF
--- a/R/token-define.R
+++ b/R/token-define.R
@@ -63,7 +63,8 @@ op_token <- c(
   logical_token,
   left_assignment_token,
   right_assignment_token,
-  "EQ_SUB", "ELSE", "IN"
+  "EQ_SUB", "ELSE", "IN",
+  "EQ_FORMALS"
 )
 
 

--- a/tests/testthat/parse_comments/rplumber-out.R
+++ b/tests/testthat/parse_comments/rplumber-out.R
@@ -1,7 +1,7 @@
 # myfile.R
 
 #* @get /mean
-normalMean <- function(samples=10) {
+normalMean <- function(samples = 10) {
   data <- rnorm(samples)
   mean(data)
 }


### PR DESCRIPTION
EQ_FORMALS belongs to the op_token set and hence spacing and other rules apply. Closes #378. 