### PR TITLE
Require cli 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ URL: https://github.com/r-lib/styler
 BugReports: https://github.com/r-lib/styler/issues
 Imports: 
     backports (>= 1.1.0),
-    cli,
+    cli (>= 1.1.0),
     magrittr (>= 1.0.1),
     purrr (>= 0.2.3),
     rematch2,


### PR DESCRIPTION
`test-public_api.R` uses `cli::is_utf8_output()` which wasn't present/exported in earlier versions of `cli`.