### PR TITLE
Make Addin for selection styling respecting line breaks in general

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -90,7 +90,7 @@ style_selection <- function() {
   if (all(nchar(text) == 0)) abort("No code selected")
   out <- style_text(text, transformers = get_addins_style_transformer())
   rstudioapi::modifyRange(
-    context$selection[[1]]$range, paste0(out, collapse = "\n"),
+    context$selection[[1]]$range, paste0(c(out, if (context$selection[[1]]$range$end[2] == 1) ""), collapse = "\n"),
     id = context$id
   )
   if (Sys.getenv("save_after_styling") == TRUE && context$path != "") {


### PR DESCRIPTION
Previously, the Addin did not support selecting the last line to style as a full line as shown below in the sense that it resulted in a line break removed and resulted in invalid R code.

![Screen Shot 2019-06-16 at 13 36 20](https://user-images.githubusercontent.com/10477073/59563530-bbd0bc00-903b-11e9-9ce0-df6b8045a0a1.png)

resulted in 
```r 
1 + 1 q
```

For the last line selected for styling, one had to select a finite `col2` value to prevent this.
![Screen Shot 2019-06-16 at 13 39 09](https://user-images.githubusercontent.com/10477073/59563572-208c1680-903c-11e9-8166-c625c971e180.png)
This resulted in the correct styling 
```r
1 + 1
q
```

This PR removes the constraint of having to select the code as in the second example (i.e. a non-finite `col2` value is no longer needed) and closes #519.