### PR TITLE
Release v1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: styler
 Type: Package
 Title: Non-Invasive Pretty Printing of R Code
-Version: 1.1.1.9003
+Version: 1.2.0
 Authors@R: 
     c(person(given = "Kirill",
              family = "Müller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,10 @@
 * styler is now available through the pre-commit hook `style-files` in
   https://github.com/lorenzwalthert/pre-commit-hooks.
 
+Thanks to all contributors involved, in particular
+
+[&#x0040;Banana1530](https://github.com/Banana1530), [&#x0040;batpigandme](https://github.com/batpigandme), [&#x0040;cpsievert](https://github.com/cpsievert), [&#x0040;ellessenne](https://github.com/ellessenne), [&#x0040;Emiller88](https://github.com/Emiller88), [&#x0040;hadley](https://github.com/hadley), [&#x0040;IndrajeetPatil](https://github.com/IndrajeetPatil), [&#x0040;krlmlr](https://github.com/krlmlr), [&#x0040;lorenzwalthert](https://github.com/lorenzwalthert), [&#x0040;lwjohnst86](https://github.com/lwjohnst86), [&#x0040;michaelquinn32](https://github.com/michaelquinn32), [&#x0040;mine-cetinkaya-rundel](https://github.com/mine-cetinkaya-rundel), [&#x0040;Moohan](https://github.com/Moohan), [&#x0040;nxskok](https://github.com/nxskok), [&#x0040;oliverbeagley](https://github.com/oliverbeagley), [&#x0040;pat-s](https://github.com/pat-s), [&#x0040;reddy-ia](https://github.com/reddy-ia), and [&#x0040;russHyde](https://github.com/russHyde)
+
 # styler 1.1.1
 
 This is primarily a maintenance release upon the request of the CRAN team

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,8 +7,8 @@
   This is also reflected in the invisible return value of the function (#522).
 
 * `style_file()` and friends do not write content back to a file when styling
-  does not cause any changes in the file. This means the modification date of
-  files styled is only changed when the content is changed (#532).
+  does not cause any changes in the file. This means the modification date of 
+  styled files is only changed when the content is changed (#532).
 
 ## New features
 
@@ -16,9 +16,9 @@
   [definition for aligned function calls](https://styler.r-lib.org/articles/detect-alignment.html)
   (#537).
 
-* curly-curly (`{{`) syntactic sugar introduced with rlang 0.4.0 is now
-  explicitly handled, as opposed previously where it was just treated as two
-  consecutive curly braces (#528).
+* curly-curly (`{{`) syntactic sugar introduced with rlang 0.4.0 is now 
+  explicitly handled, where previously it was just treated as two consecutive 
+  curly braces (#528).
 
 * `style_pkg()`, `style_dir()` and the Addins can now style `.Rprofile`, and
   hidden files are now also styled (#530).

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,7 @@
 
 * Escape characters in roxygen code examples are now correctly escaped (#512).
 
-* Special characters such as `\n` in strings are now preseved in text and not 
+* Special characters such as `\n` in strings are now preserved in text and not 
   turned into literal values like a line break (#554).
 
 * Style selection Addin now preserves line break when the last line selected is

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# styler 1.1.1.9000
+# styler 1.2.0
 
 ## Breaking changes
 

--- a/R/detect-alignment-utils.R
+++ b/R/detect-alignment-utils.R
@@ -140,7 +140,7 @@ alignment_serialize <- function(pd_sub) {
   }
 }
 
-#' Check if spacing around comma is correcr
+#' Check if spacing around comma is correct
 #'
 #' At least one space after comma, none before, for all but the last comma on
 #' the line

--- a/R/rules-spacing.R
+++ b/R/rules-spacing.R
@@ -1,6 +1,6 @@
 #' Set spaces around operators
 #'
-#' Alignement is kept, if detected.
+#' Alignment is kept, if detected.
 #' @include token-define.R
 #' @keywords internal
 #' @include token-define.R

--- a/R/testing.R
+++ b/R/testing.R
@@ -196,7 +196,7 @@ testthat_file <- function(...) {
   file.path(rprojroot::find_testthat_root_file(), ...)
 }
 
-#' Convert a serialized R object to a certaion verion.
+#' Convert a serialized R object to a certaion version.
 #'
 #' Needed to make [testthat::expect_known_value()] work on R < 3.6.
 #' @param path A path to an rds file.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Test environments
 
-* local OS X install (10.14.3): R 3.6
+* local OS X install (10.14.6): R 3.6.0
 * ubuntu 14.04 (on travis-ci): R devel, R 3.6, R 3.5, R 3.4, R 3.2
 * r-hub: R devel (Windows and Linux) and R 3.6 (Windows and Linux).
 * win-builder: R devel, R 3.6 
@@ -13,9 +13,8 @@
 
 I also ran R CMD check on all downstream dependencies of styler using the 
 revdepcheck package. The 
-downstream dependencies are: exampletestr, languageserver, autothresholdr, 
-crunch, detrendr, drake, knitr, nandb, reprex, shinydashboardPlus, 
-tradestatistics, usethis. 
+downstream dependencies are: exampletestr, languageserver, crunch, 
+drake, knitr, nph, reprex, shinydashboardPlus, tradestatistics, usethis.
 
 All of them finished R CMD CHECK with the same number of ERRORS, WARNINGS and 
 NOTES as with the current CRAN version of styler, which means the new 

--- a/man/alignment_has_correct_spacing_around_comma.Rd
+++ b/man/alignment_has_correct_spacing_around_comma.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/detect-alignment-utils.R
 \name{alignment_has_correct_spacing_around_comma}
 \alias{alignment_has_correct_spacing_around_comma}
-\title{Check if spacing around comma is correcr}
+\title{Check if spacing around comma is correct}
 \usage{
 alignment_has_correct_spacing_around_comma(pd_sub)
 }

--- a/man/rds_to_version.Rd
+++ b/man/rds_to_version.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/testing.R
 \name{rds_to_version}
 \alias{rds_to_version}
-\title{Convert a serialized R object to a certaion verion.}
+\title{Convert a serialized R object to a certaion version.}
 \usage{
 rds_to_version(path, version = 2)
 }

--- a/man/set_space_around_op.Rd
+++ b/man/set_space_around_op.Rd
@@ -7,6 +7,6 @@
 set_space_around_op(pd_flat, strict)
 }
 \description{
-Alignement is kept, if detected.
+Alignment is kept, if detected.
 }
 \keyword{internal}

--- a/tests/testthat/test-start_line.R
+++ b/tests/testthat/test-start_line.R
@@ -1,6 +1,6 @@
 context("start token")
 
-test_that("leading spaces are preseved at start of text", {
+test_that("leading spaces are preserved at start of text", {
   expect_warning(test_collection("start_line",
                   transformer = style_empty, write_back = TRUE), NA)
 })


### PR DESCRIPTION
I think we should do that because #534 is pressing and I don't want people to stop using styler simply because the CRAN version does not handle `{{` well, although there is also https://github.com/tidyverse/style/pull/140. 

Prepare for release:

* [x] `devtools::check_win_devel()`
* [x] `rhub::check_for_cran()`
* [x] `revdepcheck::revdep_check(num_workers = 4)`
* [x] [Polish NEWS](http://style.tidyverse.org/news.html#before-release)
* [x] If new failures, update `email.yml` then `revdepcheck::revdep_email_maintainers()`

Why not just `devtools::release()`?
Perform release:

* [x] Create RC branch (for bigger releases)
* [x] Bump version (in DESCRIPTION and NEWS)
* [x] `devtools::check_win_devel()` (again!)
* [ ] `devtools::submit_cran()`
* [x] `pkgdown::build_site()`
* [ ] Approve email

Wait for CRAN...

* [ ] Tag release
* [ ] Merge RC back to master branch
* [ ] Bump dev version
* [ ] Write blog post
* [ ] Tweet
* [ ] Add link to blog post in pkgdown news menu

Template from <https://github.com/r-lib/usethis/issues/338>