### PR TITLE
Fix caching for multi-token one-line expression with partial caching

### DIFF
--- a/R/nest.R
+++ b/R/nest.R
@@ -243,7 +243,8 @@ add_terminal_token_before <- function(pd_flat) {
 #' @describeIn add_token_terminal Initializes `newlines` and `lag_newlines`.
 #' @keywords internal
 add_attributes_caching <- function(pd_flat, transformers) {
-  pd_flat$block <- pd_flat$is_cached <- rep(NA, nrow(pd_flat))
+  pd_flat$block  <- rep(NA, nrow(pd_flat))
+  pd_flat$is_cached <- rep(FALSE, nrow(pd_flat))
   if (cache_is_activated()) {
     is_parent <- pd_flat$parent == 0
     pd_flat$is_cached[is_parent] <- map_lgl(

--- a/R/token-create.R
+++ b/R/token-create.R
@@ -37,7 +37,7 @@ create_tokens <- function(tokens,
                           child = NULL,
                           stylerignore = FALSE,
                           block = NA,
-                          is_cached = NA) {
+                          is_cached = FALSE) {
   len_text <- length(texts)
   new_tibble(
     list(

--- a/R/visit.R
+++ b/R/visit.R
@@ -128,7 +128,7 @@ context_towards_terminals <- function(pd_nested,
 #' @keywords internal
 extract_terminals <- function(pd_nested) {
   bind_rows(
-    ifelse(pd_nested$terminal, split(pd_nested, seq_len(nrow(pd_nested))),
+    ifelse(pd_nested$terminal | pd_nested$is_cached, split(pd_nested, seq_len(nrow(pd_nested))),
       pd_nested$child
     )
   )

--- a/man/create_tokens.Rd
+++ b/man/create_tokens.Rd
@@ -18,7 +18,7 @@ create_tokens(
   child = NULL,
   stylerignore = FALSE,
   block = NA,
-  is_cached = NA
+  is_cached = FALSE
 )
 }
 \arguments{

--- a/tests/testthat/test-cache-high-level-api.R
+++ b/tests/testthat/test-cache-high-level-api.R
@@ -191,12 +191,10 @@ capture.output(test_that("partial caching of multiple expressions on one line wo
   )
 
   style_text("mtcars")
-  style_text("mtcars %>%
-  f()")
-  final_text <- "mtcars %>%
-  f() #"
+  style_text(c("mtcars %>%", "f()"))
+  final_text <- c("mtcars %>%", "  f() #")
   expect_equal(
     as.character(style_text(final_text)),
-    final_text,
+    final_text
   )
 }))

--- a/tests/testthat/test-cache-high-level-api.R
+++ b/tests/testthat/test-cache-high-level-api.R
@@ -189,7 +189,7 @@ capture.output(test_that("partial caching of multiple expressions on one line wo
   text <- "1"
   style_text(text)
   text2 <- "1 # comment"
-  styled <- style_text(text)
+  styled <- style_text(text2)
   expect_equal(
     as.character(styled),
     text2

--- a/tests/testthat/test-cache-high-level-api.R
+++ b/tests/testthat/test-cache-high-level-api.R
@@ -179,3 +179,19 @@ capture.output(test_that("avoid removing roxygen mask (see commit messages in #5
     text2
   )
 }))
+
+
+capture.output(test_that("partial caching of multiple expressions on one line works", {
+
+  on.exit(clear_testthat_cache())
+  clear_testthat_cache()
+  activate_testthat_cache()
+  text <- "1"
+  style_text(text)
+  text2 <- "1 # comment"
+  styled <- style_text(text)
+  expect_equal(
+    as.character(styled),
+    text2
+  )
+}))

--- a/tests/testthat/test-cache-high-level-api.R
+++ b/tests/testthat/test-cache-high-level-api.R
@@ -24,7 +24,6 @@ text <- c(
   rep(10)
 
 capture.output(test_that("activated cache brings speedup on style_text() API on character vector", {
-
   activate_testthat_cache()
   on.exit(clear_testthat_cache())
   clear_testthat_cache()
@@ -36,7 +35,6 @@ capture.output(test_that("activated cache brings speedup on style_text() API on 
 }))
 
 capture.output(test_that("activated cache brings speedup on style_text() API on character scalar", {
-
   activate_testthat_cache()
   on.exit(clear_testthat_cache())
   clear_testthat_cache()
@@ -75,7 +73,8 @@ test_that("trailing line breaks are ignored for caching in one scalar", {
   second <- system.time(
     styler::style_text(
       paste0(paste0(text, collapse = "\n"), "\n", "\n", "\n", "\n", collapse = "")
-  ))
+    )
+  )
   expect_true(first["elapsed"] / 2 > second["elapsed"])
   # check we only have three different expressions. Top-level, example and fun.
   cache_info <- cache_info()
@@ -86,7 +85,6 @@ test_that("trailing line breaks are ignored for caching in one scalar", {
 })
 
 capture.output(test_that("no speedup when tranformer changes", {
-
   activate_testthat_cache()
   on.exit(clear_testthat_cache())
   clear_testthat_cache()
@@ -112,11 +110,11 @@ capture.output(
     first <- system.time(styler::style_text(text))
     second <- system.time(styler::style_text(paste0(text, collapse = "\n")))
     expect_true(first["elapsed"] / 2 > second["elapsed"])
-  }))
+  })
+)
 
 
 capture.output(test_that("unactivated cache does not bring speedup", {
-
   on.exit(clear_testthat_cache())
   clear_testthat_cache()
   cache_deactivate()
@@ -127,7 +125,6 @@ capture.output(test_that("unactivated cache does not bring speedup", {
 
 
 capture.output(test_that("avoid deleting comments #584 (see commit messages)", {
-
   on.exit(clear_testthat_cache())
   clear_testthat_cache()
   activate_testthat_cache()
@@ -136,7 +133,7 @@ capture.output(test_that("avoid deleting comments #584 (see commit messages)", {
     "# Comment",
     "# another",
     "NULL"
-    )
+  )
   style_text(text)
   text2 <- c(
     "1 + 1",
@@ -152,7 +149,6 @@ capture.output(test_that("avoid deleting comments #584 (see commit messages)", {
 
 
 capture.output(test_that("avoid removing roxygen mask (see commit messages in #584)", {
-
   on.exit(clear_testthat_cache())
   clear_testthat_cache()
   activate_testthat_cache()
@@ -182,7 +178,6 @@ capture.output(test_that("avoid removing roxygen mask (see commit messages in #5
 
 
 capture.output(test_that("partial caching of multiple expressions on one line works", {
-
   on.exit(clear_testthat_cache())
   clear_testthat_cache()
   activate_testthat_cache()
@@ -193,5 +188,15 @@ capture.output(test_that("partial caching of multiple expressions on one line wo
   expect_equal(
     as.character(styled),
     text2
+  )
+
+  style_text("mtcars")
+  style_text("mtcars %>%
+  f()")
+  final_text <- "mtcars %>%
+  f() #"
+  expect_equal(
+    as.character(style_text(final_text)),
+    final_text,
   )
 }))


### PR DESCRIPTION
Closes #592. We now set `is_cached` for all tokens to `FALSE` for all tokens we are not sure if they are cached or not. Also, `create_new_tokens()` defaults to `is_cached = FALSE` for new tokens. They could only be cached if they were top level expressions, but newly created tokens are in the current implementation of styler often added curly braces or similar, so they won't probably ever be top-level expressions.