### PR TITLE
Don't cache stylerignore sequences

### DIFF
--- a/man/cache_by_expression.Rd
+++ b/man/cache_by_expression.Rd
@@ -13,6 +13,9 @@ cache_by_expression(text, transformers)
 }
 \description{
 Splits \code{text} into expressions and adds these to the cache. Note that
-comments are \strong{not} cached because caching them is too expensive.
+comments are \strong{not} cached because caching them is too expensive. Also, we
+must not cache stylerignore sequence, because we might see the same
+expression that does not comply with the style guide outside a stylerignore
+sequence and wrongly think we should leave it as is.
 }
 \keyword{internal}

--- a/tests/testthat/test-interaction-caching-stylerignore.R
+++ b/tests/testthat/test-interaction-caching-stylerignore.R
@@ -134,3 +134,23 @@ test_that("caching works for non-top-level expressions", {
   )
 })
 
+test_that("does not cache stylerignore sequences", {
+  on.exit(clear_testthat_cache())
+  fresh_testthat_cache()
+  text <- c(
+    "1+1# styler: off"
+  )
+  style_text(text)
+  expect_false(
+    is_cached("1+1", tidyverse_style())
+  )
+  fresh_testthat_cache()
+  text <- c(
+    "# styler: off",
+    "1+1"
+  )
+  style_text(text)
+  expect_false(
+    is_cached("1+1", tidyverse_style())
+  )
+})


### PR DESCRIPTION
When caching by expression, we need to parse again and `add_stylerignore()` to then drop these `text` before caching. Closes #608.