### PR TITLE
Parallel styling of files by `style_pkg` & `style_dir` (#277)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     tools,
     withr (>= 1.0.0),
     xfun (>= 0.1),
-    furrr
+    future.apply
 Suggests: 
     data.tree (>= 0.1.6),
     digest,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Imports:
     tibble (>= 1.4.2),
     tools,
     withr (>= 1.0.0),
-    xfun (>= 0.1)
+    xfun (>= 0.1),
+    furrr
 Suggests: 
     data.tree (>= 0.1.6),
     digest,

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@ Release upon request by the CRAN team.
 - skip timing tests on CRAN as requested by CRAN team because they did not pass 
   on all machines (#603).
 
+## New features
+
+* `style_pkg()` and `style_dir()` gain the ability to run in parallel using 
+  `future` backends.
+
 # styler 1.3.1
 
 Emergency release. In case multiple expressions are on one line and only 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ Release upon request by the CRAN team.
 ## New features
 
 * `style_pkg()` and `style_dir()` gain the ability to run in parallel using 
-  `future` backends.
+  `future` backends (#277).
 
 # styler 1.3.1
 

--- a/R/transform-files.R
+++ b/R/transform-files.R
@@ -20,9 +20,11 @@ transform_files <- function(files,
     cat("Styling ", len_files, " files:\n")
   }
 
-  changed <- furrr::future_map_lgl(files, transform_file,
+  changed <- future.apply::future_sapply(
+    files, transform_file,
     fun = transformer, max_char_path = max_char, root = root
   )
+
   communicate_summary(changed, max_char)
   communicate_warning(changed, transformers)
   new_tibble(list(file = files, changed = changed), nrow = len_files)

--- a/R/transform-files.R
+++ b/R/transform-files.R
@@ -12,7 +12,7 @@
 transform_files <- function(files,
                             transformers,
                             include_roxygen_examples,
-                            pkg_root = ".") {
+                            root = ".") {
   transformer <- make_transformer(transformers, include_roxygen_examples)
   max_char <- min(max(nchar(files), 0), getOption("width"))
   len_files <- length(files)
@@ -21,7 +21,7 @@ transform_files <- function(files,
   }
 
   changed <- furrr::future_map_lgl(files, transform_file,
-    fun = transformer, max_char_path = max_char, pkg_root = pkg_root
+    fun = transformer, max_char_path = max_char, root = root
   )
   communicate_summary(changed, max_char)
   communicate_warning(changed, transformers)
@@ -46,7 +46,7 @@ transform_file <- function(path,
                            message_before = "",
                            message_after = " [DONE]",
                            message_after_if_changed = " *",
-                           pkg_root = ".",
+                           root = ".",
                            ...) {
   char_after_path <- nchar(message_before) + nchar(path) + 1
   max_char_after_message_path <- nchar(message_before) + max_char_path + 1
@@ -57,7 +57,7 @@ transform_file <- function(path,
     rep_char(" ", max(0L, n_spaces_before_message_after)),
     append = FALSE
   )
-  setwd(pkg_root)
+  setwd(root)
   changed <- transform_code(path, fun = fun, ...)
 
   bullet <- ifelse(is.na(changed), "warning", ifelse(changed, "info", "tick"))

--- a/R/ui-styling.R
+++ b/R/ui-styling.R
@@ -199,7 +199,8 @@ style_dir <- function(path = ".",
   changed <- withr::with_dir(
     path, prettify_any(
       transformers,
-      filetype, recursive, exclude_files, exclude_dirs, include_roxygen_examples
+      filetype, recursive, exclude_files, exclude_dirs,
+      include_roxygen_examples, path
     )
   )
   invisible(changed)
@@ -217,7 +218,8 @@ prettify_any <- function(transformers,
                          recursive,
                          exclude_files,
                          exclude_dirs,
-                         include_roxygen_examples) {
+                         include_roxygen_examples,
+                         path = ".") {
   exclude_files <- set_arg_paths(exclude_files)
   exclude_dirs <- set_arg_paths(exclude_dirs)
   files_root <- dir(
@@ -237,7 +239,7 @@ prettify_any <- function(transformers,
   }
   transform_files(
     setdiff(c(files_root, files_other), exclude_files),
-    transformers, include_roxygen_examples
+    transformers, include_roxygen_examples, path
   )
 }
 

--- a/R/ui-styling.R
+++ b/R/ui-styling.R
@@ -82,7 +82,7 @@ style_pkg <- function(pkg = ".",
   pkg_root <- rprojroot::find_package_root_file(path = pkg)
   changed <- withr::with_dir(pkg_root, prettify_pkg(
     transformers,
-    filetype, exclude_files, exclude_dirs, include_roxygen_examples
+    filetype, exclude_files, exclude_dirs, include_roxygen_examples, pkg_root
   ))
   invisible(changed)
 }
@@ -91,7 +91,8 @@ prettify_pkg <- function(transformers,
                          filetype,
                          exclude_files,
                          exclude_dirs,
-                         include_roxygen_examples) {
+                         include_roxygen_examples,
+                         pkg_root = ".") {
   filetype <- set_and_assert_arg_filetype(filetype)
   r_files <- rprofile_files <- vignette_files <- readme <- NULL
   exclude_files <- set_arg_paths(exclude_files)
@@ -137,7 +138,7 @@ prettify_pkg <- function(transformers,
     c(r_files, rprofile_files, vignette_files, readme),
     exclude_files
   )
-  transform_files(files, transformers, include_roxygen_examples)
+  transform_files(files, transformers, include_roxygen_examples, pkg_root)
 }
 
 #' Style a string

--- a/R/ui-styling.R
+++ b/R/ui-styling.R
@@ -69,6 +69,10 @@ NULL
 #'   scope = "line_breaks",
 #'   math_token_spacing = specify_math_token_spacing(zero = "'+'")
 #' )
+#' # For parallel operation:
+#' library(future)
+#' plan(multisession, workers = 4)
+#' style_pkg()
 #' }
 #' @export
 style_pkg <- function(pkg = ".",
@@ -185,6 +189,10 @@ style_text <- function(text,
 #' @examples
 #' \dontrun{
 #' style_dir(file_type = "r")
+#' # For parallel operation:
+#' library(future)
+#' plan(multisession, workers = 4)
+#' style_dir()
 #' }
 #' @export
 style_dir <- function(path = ".",

--- a/man/prettify_any.Rd
+++ b/man/prettify_any.Rd
@@ -10,7 +10,8 @@ prettify_any(
   recursive,
   exclude_files,
   exclude_dirs,
-  include_roxygen_examples
+  include_roxygen_examples,
+  path = "."
 )
 }
 \arguments{

--- a/man/style_dir.Rd
+++ b/man/style_dir.Rd
@@ -95,6 +95,10 @@ See section 'Warning' for a good strategy to apply styling safely.
 \examples{
 \dontrun{
 style_dir(file_type = "r")
+# For parallel operation:
+library(future)
+plan(multisession, workers = 4)
+style_dir()
 }
 }
 \seealso{

--- a/man/style_pkg.Rd
+++ b/man/style_pkg.Rd
@@ -99,6 +99,10 @@ style_pkg(
   scope = "line_breaks",
   math_token_spacing = specify_math_token_spacing(zero = "'+'")
 )
+# For parallel operation:
+library(future)
+plan(multisession, workers = 4)
+style_pkg()
 }
 }
 \seealso{

--- a/man/transform_file.Rd
+++ b/man/transform_file.Rd
@@ -11,6 +11,7 @@ transform_file(
   message_before = "",
   message_after = " [DONE]",
   message_after_if_changed = " *",
+  root = ".",
   ...
 )
 }

--- a/man/transform_files.Rd
+++ b/man/transform_files.Rd
@@ -4,7 +4,7 @@
 \alias{transform_files}
 \title{Transform files with transformer functions}
 \usage{
-transform_files(files, transformers, include_roxygen_examples)
+transform_files(files, transformers, include_roxygen_examples, root = ".")
 }
 \arguments{
 \item{files}{A character vector with paths to the file that should be


### PR DESCRIPTION
Implements parallel styling of files by the `style_pkg` & `style_dir` functions addressing issue #277 using the `future` and `future.apply` packages.

Example of how a user would get parallel styling:

    library(future)
    plan(multisession, workers = 4)
    style_pkg()