### PR TITLE
Depreciate env var save_after_styling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,12 @@
 
 ## Major changes
 
+
+- The environment variable `save_after_styling` is deprecated in favor of 
+  the R option `styler.save_after_styling` to control if a file is saved after 
+  styling with the RStudio Addin. Note than in RStudio >= 1.3.0, you can 
+  auto-save edits in general (Code -> Saving -> Auto-Save), e.g. on idle editor 
+  or focus loss, so this feature becomes less relevant. (#631).
 - blank lines in function calls and headers are now removed, for the former only 
   when there are no comments before or after the blank line (#629, #630, #635).
 - speed improvements: (~10%) when cache is activated because transformers are not 

--- a/man/styler_addins.Rd
+++ b/man/styler_addins.Rd
@@ -30,7 +30,7 @@ code instead of the whole file.
 
 By default, both of the RStudio Addins will apply styling to the (selected)
 file contents without saving changes. Automatic saving can be enabled by
-setting the environment variable \code{save_after_styling} to \code{TRUE}.
+setting the R option \code{styler.save_after_styling} to \code{TRUE}.
 Consider setting this in your \code{.Rprofile} file if you want to persist
 this setting across multiple sessions. Untitled files will always need to be
 saved manually after styling.
@@ -49,7 +49,7 @@ the current status of this.
 \examples{
 \dontrun{
 # save after styling when using the Addin
-Sys.setenv(save_after_styling = TRUE)
+options(styler.save_after_styling = TRUE)
 # only style with scope = "spaces" when using the Addin
 options(
   styler.addins_style_transformer = "styler::tidyverse_style(scope = 'spaces')"

--- a/tests/testthat/test-public_api.R
+++ b/tests/testthat/test-public_api.R
@@ -377,7 +377,6 @@ test_that("base indention works", {
   )
 })
 
-
 test_that("scope can be specified as is", {
   capture_output(expect_false({
     styled <- style_pkg(testthat_file("public-api", "xyzpackage"), scope = I("spaces"))
@@ -393,4 +392,34 @@ test_that("scope can be specified as is", {
     style_text(c("1+14;x=2"), scope = I(c("line_breaks", "tokens"))),
     construct_vertical(c("1+14", "x<-2"))
   )
+})
+
+test_that("Can properly determine style_after_saving", {
+  withr::with_envvar(list(save_after_styling = TRUE), {
+    expect_warning(op <- save_after_styling_is_active(), "is depreciated")
+    expect_equal(op, TRUE)
+  })
+
+  withr::with_envvar(list(save_after_styling = FALSE), {
+    expect_warning(op <- save_after_styling_is_active(), "is depreciated")
+    expect_equal(op, FALSE)
+  })
+
+
+  withr::with_options(list(styler.save_after_styling = TRUE), {
+    expect_silent(op <- save_after_styling_is_active())
+    expect_equal(op, TRUE)
+  })
+
+  withr::with_options(list(styler.save_after_styling = TRUE), {
+    withr::with_envvar(list(save_after_styling = FALSE), {
+      expect_warning(op <- save_after_styling_is_active(), "is depreciated")
+      expect_equal(op, TRUE)
+    })
+  })
+
+  withr::with_options(list(styler.save_after_styling = FALSE), {
+    expect_silent(op <- save_after_styling_is_active())
+    expect_equal(op, FALSE)
+  })
 })


### PR DESCRIPTION
Closes #555. But wait until decided if default should no longer be false, but depend on rstudio < 1.3, because 1.3. introduces autosaving (only when curser is away from the editor).