### PR TITLE
Add benchmarking infra

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,4 +19,5 @@ revdep
 ^tests/testmanual$
 ^\.pre-commit-config\.yaml$
 ^brew\-log$
-^\.github$
+^\.github/$
+^bench/$

--- a/.github/workflows/benchmarking.yaml
+++ b/.github/workflows/benchmarking.yaml
@@ -47,7 +47,7 @@ jobs:
           ref: v0.1
           path: bench/sources/here
       - name: Fetch existing benchmarks
-        run: Rscript -e '#bench::cb_fetch()'
+        run: Rscript -e 'bench::cb_fetch()'
       - name: Run benchmarks
         run: Rscript -e 'bench::cb_run()'
       - name: Show benchmarks

--- a/.github/workflows/benchmarking.yaml
+++ b/.github/workflows/benchmarking.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
         uses: actions/checkout@master
-      - name: Ensure master branch is fetched
+      - name: Ensure base branch is fetched
         if: ${{ github.event_name == 'pull_request' }}
         run: git branch $GITHUB_BASE_REF remotes/origin/$GITHUB_BASE_REF; git branch
       - name: Setup R

--- a/.github/workflows/benchmarking.yaml
+++ b/.github/workflows/benchmarking.yaml
@@ -43,8 +43,8 @@ jobs:
       - name: Checkout benchmarking repo
         uses: actions/checkout@v2
         with:
-          repository: r-lib/here
-          ref: v0.1
+          repository: lorenzwalthert/here
+          ref: ca9c8e69c727def88d8ba1c8b85b0e0bcea87b3f
           path: bench/sources/here
       - name: Fetch existing benchmarks
         run: Rscript -e 'bench::cb_fetch()'

--- a/.github/workflows/benchmarking.yaml
+++ b/.github/workflows/benchmarking.yaml
@@ -47,7 +47,7 @@ jobs:
           ref: ca9c8e69c727def88d8ba1c8b85b0e0bcea87b3f
           path: bench/sources/here
       - name: Fetch existing benchmarks
-        run: Rscript -e 'bench::cb_fetch()'
+        run: Rscript -e 'rlang::with_handlers(bench::cb_fetch(), error = function(e) paste("Could not fetch benchmarks, skipping. The error was", conditionMessage(e)))'
       - name: Run benchmarks
         run: Rscript -e 'bench::cb_run()'
       - name: Show benchmarks

--- a/.github/workflows/benchmarking.yaml
+++ b/.github/workflows/benchmarking.yaml
@@ -1,0 +1,61 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+name: Continuous Benchmarks
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout repo
+        with:
+          fetch-depth: 0
+        uses: actions/checkout@master
+      - name: Ensure master branch is fetched
+        if: ${{ github.event_name == 'pull_request' }}
+        run: git branch $GITHUB_BASE_REF remotes/origin/$GITHUB_BASE_REF; git branch
+      - name: Setup R
+        uses: r-lib/actions/setup-r@master
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        if: runner.os != 'Windows'
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          Rscript -e "install.packages(c('gert', 'ggplot2', 'purrr'))" -e "remotes::install_deps(dependencies = TRUE); remotes::install_github('r-lib/bench')"
+          R CMD INSTALL .
+      - name: Checkout benchmarking repo
+        uses: actions/checkout@v2
+        with:
+          repository: r-lib/here
+          ref: v0.1
+          path: bench/sources/here
+      - name: Fetch existing benchmarks
+        run: Rscript -e '#bench::cb_fetch()'
+      - name: Run benchmarks
+        run: Rscript -e 'bench::cb_run()'
+      - name: Show benchmarks
+        run: git notes --ref benchmarks show
+      - uses: actions/upload-artifact@v2
+        with:
+          name: visual-benchmarks
+          path: bench/plots/
+      - name: Push benchmarks
+        if: ${{ github.event_name == 'push' }}
+        run: Rscript -e "bench::cb_push()"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
         exclude: >
           (?x)^(
           data/.*|
+          \.github/.*\.yaml|
           (.*/|)\.Rprofile|
           (.*/|)\.Renviron|
           (.*/|)\.gitignore|
@@ -35,6 +36,10 @@ repos:
     -   id: parsable-R
     -   id: no-browser-statement
     -   id: deps-in-desc
+        exclude: >
+          (?x)^(
+          bench/.*
+          )$
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:

--- a/bench/01-declarations.R
+++ b/bench/01-declarations.R
@@ -7,25 +7,30 @@ plot_against_base <- function(new_bm,
                               new_bm_label = deparse(substitute(new_bm)),
                               file = paste0("plots/", new_bm_label, ".pdf")) {
   new_bm <- bench::as_bench_mark(new_bm)
+  name <- unique(new_bm$name)
+  stopifnot(length(name) == 1)
   branches <- gert::git_branch_list()
   last_commit_base_branch <- branches[branches$name == Sys.getenv("GITHUB_BASE_REF"), "commit", drop = TRUE]
   bm <- bench::cb_read()
   commit_is_reference <- bm$commit_hash == last_commit_base_branch
   if (any(commit_is_reference) && Sys.getenv("GITHUB_BASE_REF") != "") {
     # if a pull request
-    reference <- bm[commit_is_reference, "benchmarks"][[1]][[1]]
+    reference <- bm[commit_is_reference, "benchmarks"][[1]][[1]] %>%
+      dplyr::filter(.data$name %in% !!name)
     reference$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_BASE_REF"))
     new_bm$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_HEAD_REF"))
-    new_bm <- rbind(reference, new_bm)
+    new_bm <- dplyr::bind_rows(reference, new_bm)
+    new_bm$branch <- factor(new_bm$expression)
   }
   plot <- ggplot2::ggplot(new_bm) +
     ggplot2::geom_boxplot(ggplot2::aes(
-      x = name, ymin = p0,
+      x = branch, ymin = p0,
       ymax = p100, lower = p25,
       middle = p50, upper = p75
     ),
     stat = "identity"
-    )
+    ) +
+    ggplot2::ggtitle(name)
 
   ggplot2::ggsave(file, plot)
 }

--- a/bench/01-declarations.R
+++ b/bench/01-declarations.R
@@ -7,23 +7,24 @@ plot_against_base <- function(new_bm,
                               new_bm_label = deparse(substitute(new_bm)),
                               file = paste0("plots/", new_bm_label, ".pdf")) {
   new_bm <- bench::as_bench_mark(new_bm)
+  new_bm$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_HEAD_REF"))
   name <- unique(new_bm$name)
   stopifnot(length(name) == 1)
   branches <- gert::git_branch_list()
   last_commit_base_branch <- branches[branches$name == Sys.getenv("GITHUB_BASE_REF"), "commit", drop = TRUE]
   bm <- bench::cb_read()
-  print("bm is")
-  print(bm)
   commit_is_reference <- bm$commit_hash == last_commit_base_branch
-  if (any(commit_is_reference) && Sys.getenv("GITHUB_BASE_REF") != "" && !is.null(bm) && nrow(bm) > 0) {
+  if (any(commit_is_reference) && Sys.getenv("GITHUB_BASE_REF") != "") {
     # if a pull request
-    reference <- bm[commit_is_reference, "benchmarks"][[1]][[1]] %>%
-      dplyr::filter(.data$name %in% !!name)
-    reference$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_BASE_REF"))
-    new_bm$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_HEAD_REF"))
-    new_bm <- dplyr::bind_rows(reference, new_bm)
-    new_bm$branch <- factor(new_bm$expression)
+    reference <- bm[commit_is_reference, "benchmarks"][[1]][[1]]
+    if (nrow(reference) > 0 && "name" %in% names(reference)) {
+      reference <- reference %>%
+        dplyr::filter(.data$name %in% !!name)
+      reference$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_BASE_REF"))
+      new_bm <- dplyr::bind_rows(reference, new_bm)
+    }
   }
+  new_bm$branch <- factor(new_bm$expression)
   plot <- ggplot2::ggplot(new_bm) +
     ggplot2::geom_boxplot(ggplot2::aes(
       x = branch, ymin = p0,

--- a/bench/01-declarations.R
+++ b/bench/01-declarations.R
@@ -1,20 +1,19 @@
-#' Plot benchmarks against master, if benchmarks there exist
-#'
+#' Plot benchmarks against a base branch, if benchmarks there exist
 #'
 #' @param new_bm A new benchmark object.
 #' @param new_bm_label The label of the new benchmark used as a title.
 #' @param file The file path to write the plot.
-plot_against_master <- function(new_bm,
-                                new_bm_label = deparse(substitute(new_bm)),
-                                file = paste0("plots/", new_bm_label, ".pdf")) {
+plot_against_base <- function(new_bm,
+                              new_bm_label = deparse(substitute(new_bm)),
+                              file = paste0("plots/", new_bm_label, ".pdf")) {
   new_bm <- bench::as_bench_mark(new_bm)
   branches <- gert::git_branch_list()
-  master <- branches[branches$name == "master", "commit", drop = TRUE]
+  last_commit_base_branch <- branches[branches$name == Sys.getenv("GITHUB_BASE_REF"), "commit", drop = TRUE]
   bm <- bench::cb_read()
-  hash_is_master <- bm$commit_hash == master
-  if (any(hash_is_master) && Sys.getenv("GITHUB_BASE_REF") != "") {
+  commit_is_reference <- bm$commit_hash == last_commit_base_branch
+  if (any(commit_is_reference) && Sys.getenv("GITHUB_BASE_REF") != "") {
     # if a pull request
-    reference <- bm[hash_is_master, "benchmarks"][[1]][[1]]
+    reference <- bm[commit_is_reference, "benchmarks"][[1]][[1]]
     reference$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_BASE_REF"))
     new_bm$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_HEAD_REF"))
     new_bm <- rbind(reference, new_bm)

--- a/bench/01-declarations.R
+++ b/bench/01-declarations.R
@@ -1,0 +1,32 @@
+#' Plot benchmarks against master, if benchmarks there exist
+#'
+#'
+#' @param new_bm A new benchmark object.
+#' @param new_bm_label The label of the new benchmark used as a title.
+#' @param file The file path to write the plot.
+plot_against_master <- function(new_bm,
+                                new_bm_label = deparse(substitute(new_bm)),
+                                file = paste0("plots/", new_bm_label, ".pdf")) {
+  new_bm <- bench::as_bench_mark(new_bm)
+  branches <- gert::git_branch_list()
+  master <- branches[branches$name == "master", "commit", drop = TRUE]
+  bm <- bench::cb_read()
+  hash_is_master <- bm$commit_hash == master
+  if (any(hash_is_master) && Sys.getenv("GITHUB_BASE_REF") != "") {
+    # if a pull request
+    reference <- bm[hash_is_master, "benchmarks"][[1]][[1]]
+    reference$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_BASE_REF"))
+    new_bm$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_HEAD_REF"))
+    new_bm <- rbind(reference, new_bm)
+  }
+  plot <- ggplot2::ggplot(new_bm) +
+    ggplot2::geom_boxplot(ggplot2::aes(
+      x = name, ymin = p0,
+      ymax = p100, lower = p25,
+      middle = p50, upper = p75
+    ),
+    stat = "identity"
+    )
+
+  ggplot2::ggsave(file, plot)
+}

--- a/bench/01-declarations.R
+++ b/bench/01-declarations.R
@@ -12,6 +12,8 @@ plot_against_base <- function(new_bm,
   branches <- gert::git_branch_list()
   last_commit_base_branch <- branches[branches$name == Sys.getenv("GITHUB_BASE_REF"), "commit", drop = TRUE]
   bm <- bench::cb_read()
+  print("bm is")
+  print(bm)
   commit_is_reference <- bm$commit_hash == last_commit_base_branch
   if (any(commit_is_reference) && Sys.getenv("GITHUB_BASE_REF") != "" && !is.null(bm) && nrow(bm) > 0) {
     # if a pull request

--- a/bench/01-declarations.R
+++ b/bench/01-declarations.R
@@ -13,7 +13,7 @@ plot_against_base <- function(new_bm,
   last_commit_base_branch <- branches[branches$name == Sys.getenv("GITHUB_BASE_REF"), "commit", drop = TRUE]
   bm <- bench::cb_read()
   commit_is_reference <- bm$commit_hash == last_commit_base_branch
-  if (any(commit_is_reference) && Sys.getenv("GITHUB_BASE_REF") != "") {
+  if (any(commit_is_reference) && Sys.getenv("GITHUB_BASE_REF") != "" && !is.null(bm) && nrow(bm) > 0) {
     # if a pull request
     reference <- bm[commit_is_reference, "benchmarks"][[1]][[1]] %>%
       dplyr::filter(.data$name %in% !!name)

--- a/bench/02-basic.R
+++ b/bench/02-basic.R
@@ -19,7 +19,7 @@ marker <- purrr::partial(
 
 with_cache <- marker(
   with_cache = {
-    style_pkg(path)
+    style_pkg(path, filetype = c("R", "rmd"))
   }
 )
 cache_info()
@@ -28,7 +28,7 @@ cache_deactivate()
 
 without_cache <- marker(
   without_cache = {
-    style_pkg(path)
+    style_pkg(path, filetype = c("R", "rmd"))
   }
 )
 latest_bm <- bench::cb_read()$benchmarks[[1]]

--- a/bench/02-basic.R
+++ b/bench/02-basic.R
@@ -1,0 +1,36 @@
+# drop all notes
+# git update-ref -d refs/notes/benchmarks
+
+library(styler)
+library(magrittr)
+path <- "sources/here"
+dir.create("plots")
+cache_clear(ask = FALSE)
+cache_activate()
+cache_info()
+
+marker <- purrr::partial(
+  bench::mark,
+  min_iterations = 20,
+  check = FALSE,
+  filter_gc = FALSE,
+  memory = TRUE # skip uncached first round
+)
+
+with_cache <- marker(
+  with_cache = {
+    style_pkg(path)
+  }
+)
+cache_info()
+gert::git_reset("hard", repo = path)
+cache_deactivate()
+
+without_cache <- marker(
+  without_cache = {
+    style_pkg(path)
+  }
+)
+latest_bm <- bench::cb_read()$benchmarks[[1]]
+split(latest_bm, latest_bm$name) %>%
+  purrr::imap(plot_against_master)

--- a/bench/02-basic.R
+++ b/bench/02-basic.R
@@ -23,7 +23,7 @@ with_cache <- marker(
   }
 )
 cache_info()
-gert::git_reset("hard", repo = path)
+gert::git_reset_hard(repo = path)
 cache_deactivate()
 
 without_cache <- marker(

--- a/bench/02-basic.R
+++ b/bench/02-basic.R
@@ -33,4 +33,4 @@ without_cache <- marker(
 )
 latest_bm <- bench::cb_read()$benchmarks[[1]]
 split(latest_bm, latest_bm$name) %>%
-  purrr::imap(plot_against_master)
+  purrr::imap(plot_against_base)


### PR DESCRIPTION
Using `bench::mark()` and friends, we build a continuous benchmarking system. For any PR there is, we create a boxplot to visualise the distribution for timings for the base branch (e.g. master) and the branch we want to merge into the base branch (head) in one plot.

Todo: 

- [x] Use more representative code (also analysis, Rmd etc.). We could even store this code in the styler repo, just not under`bench/` directly. We should probably run two styler commands - Some files should be partly styled to test caching of top level expressions. 
- [x] Use repo we have full control over instead of public r-lib repo.
- [x] maybe create versioning for the benchmarked code, so we can later switch and know what we are comparing. This can be done with the `name` arugment in `bench::mark()`.
