### PR TITLE
chore: update the github action function name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,7 @@
 - empty lines are now removed between pipes (#645).
 - overhaul pgkdown site: Add search (#623), group function in Reference (#625).
 - always strip trailing spaces and make cache insensitive to it (#626).
-- typos in documentation (#643, #618, #614).
+- minor documentation improvements (#643, #618, #614, #677).
 
 # styler 1.3.2
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -140,7 +140,7 @@ styler functionality is made available through other tools, most notably
   Action](https://github.com/features/actions) [*Tidyverse
   CI*](https://github.com/r-lib/actions/tree/master/examples#tidyverse-ci-workflow)
   is used. The most convenient way to set this up is via
-  [`usethis::use_github_actions_tidy()`](https://usethis.r-lib.org/reference/github_actions.html?q=ghactions#use-github-actions-tidy-).
+  [`usethis::use_tidy_github_actions()`](https://usethis.r-lib.org/reference/tidyverse.html).
 
 * `reprex::reprex(style = TRUE)` to prettify reprex code before printing. To
   permanently use `style = TRUE` without specifying it every time, you can add

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ There are a few variants of `style_text()`:
   - `style_pkg()` styles the source files of an R package.
 
   - RStudio Addins for styling the active file, styling the current
-    package and styling the highlighted code
-region.
+    package and styling the highlighted code region.
 
 <img src="https://raw.githubusercontent.com/lorenzwalthert/some_raw_data/master/styler_0.1.gif" width="650px" />
 
@@ -134,7 +133,7 @@ styler functionality is made available through other tools, most notably
     Action](https://github.com/features/actions) [*Tidyverse
     CI*](https://github.com/r-lib/actions/tree/master/examples#tidyverse-ci-workflow)
     is used. The most convenient way to set this up is via
-    [`usethis::use_github_actions_tidy()`](https://usethis.r-lib.org/reference/github_actions.html?q=ghactions#use-github-actions-tidy-).
+    [`usethis::use_tidy_github_actions()`](https://usethis.r-lib.org/reference/tidyverse.html).
 
   - `reprex::reprex(style = TRUE)` to prettify reprex code before
     printing. To permanently use `style = TRUE` without specifying it
@@ -144,7 +143,7 @@ styler functionality is made available through other tools, most notably
   - you can pretty-print your R code in RMarkdown reports without having
     styler modifying the source. This feature is implemented as a code
     chunk option in knitr. use `tidy = "styler"` in the header of a code
-    chunks (e.g. ` ```{r name-of-the-chunk, tidy = "styler"}`), or
+    chunks (e.g. ` ```{r name-of-the-chunk, tidy = "styler"} `), or
     `knitr::opts_chunk$set(tidy = "styler")` at the top of your
     RMarkdown script.
 


### PR DESCRIPTION
`{usethis}` have changed the function from `use_github_actions_tidy()` to `use_tidy_github_actions()`
https://github.com/r-lib/usethis/commit/7756ec726be9d7f1f13fe49d96da9aae177833d1
No reference in `{usethis}` about `use_github_actions_tidy()` any more.

Feel free to edit it.