### PR TITLE
Speed improvement in caching 

### DIFF
--- a/.github/workflows/benchmarking.yaml
+++ b/.github/workflows/benchmarking.yaml
@@ -70,7 +70,8 @@ jobs:
       - name: Prepare PR comment
         run: |
           mkdir -p bench/pr-comment
-          echo 'Here is how the current PR would change benchmark results:\n' > bench/pr-comment/info.txt
+          echo "Here is how the current PR would change benchmark results when merged into $GITHUB_BASE_REF:" > bench/pr-comment/info.txt
+          echo "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> bench/pr-comment/info.txt
       - name: Run benchmarks
         run: Rscript -e 'bench::cb_run()'
       - name: Show benchmarks

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 - blank lines in function calls and headers are now removed, for the former only 
   when there are no comments before or after the blank line (#629, #630, #635).
+- speed improvement (~10%) when cache is activated because transformers are not 
+  captured as character anymore (#679).
 
 ## Minor changes and fixes
 

--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -91,7 +91,6 @@ cache_make_key <- function(text, transformers) {
     text = hash_standardize(text),
     style_guide_name = transformers$style_guide_name,
     style_guide_version = transformers$style_guide_version,
-    style_guide_text = as.character(transformers),
     more_specs = as.character(transformers$more_specs) %>%
       set_names(names(transformers$more_specs))
   )

--- a/bench/01-declarations.R
+++ b/bench/01-declarations.R
@@ -18,7 +18,6 @@ plot_against_base <- function(new_bm,
     # if a pull request
     reference <- bm[commit_is_reference, "benchmarks"][[1]][[1]]
     # if benchmark exists in base branch
-<<<<<<< HEAD
     if ("name" %in% names(reference)) {
       reference <- reference %>%
         dplyr::filter(.data$name %in% !!name)
@@ -31,22 +30,6 @@ plot_against_base <- function(new_bm,
         pr_comment <- glue::glue("* {name}: {round(new_bm$p50[1], 3)} -> {round(new_bm$p50[2], 3)} ({diff_in_percent}%)")
         cat(pr_comment, file = "pr-comment/info.txt", sep = "\n", append = TRUE)
       }
-=======
-    reference <- reference %>%
-      dplyr::filter(.data$name %in% !!name)
-    if (nrow(reference) > 0) {
-      # if benchmark exists in base branch
-      reference$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_BASE_REF"))
-      new_bm <- dplyr::bind_rows(reference, new_bm)
-      stopifnot(nrow(new_bm) == 2)
-      diff_in_percent <- round(100 * diff(new_bm$p50) / new_bm$p50[1])
-      diff_in_percent <- ifelse(diff_in_percent > 0,
-        paste0("+", diff_in_percent),
-        diff_in_percent
-      )
-      pr_comment <- glue::glue("* {name}: {round(new_bm$p50[1], 3)} -> {round(new_bm$p50[2], 3)} ({diff_in_percent}%)")
-      cat(pr_comment, file = "pr-comment/info.txt", sep = "\n", append = TRUE)
->>>>>>> show + if positive
     }
   }
   new_bm$branch <- factor(new_bm$expression)

--- a/bench/01-declarations.R
+++ b/bench/01-declarations.R
@@ -18,6 +18,7 @@ plot_against_base <- function(new_bm,
     # if a pull request
     reference <- bm[commit_is_reference, "benchmarks"][[1]][[1]]
     # if benchmark exists in base branch
+<<<<<<< HEAD
     if ("name" %in% names(reference)) {
       reference <- reference %>%
         dplyr::filter(.data$name %in% !!name)
@@ -30,6 +31,22 @@ plot_against_base <- function(new_bm,
         pr_comment <- glue::glue("* {name}: {round(new_bm$p50[1], 3)} -> {round(new_bm$p50[2], 3)} ({diff_in_percent}%)")
         cat(pr_comment, file = "pr-comment/info.txt", sep = "\n", append = TRUE)
       }
+=======
+    reference <- reference %>%
+      dplyr::filter(.data$name %in% !!name)
+    if (nrow(reference) > 0) {
+      # if benchmark exists in base branch
+      reference$expression <- bench:::new_bench_expr(Sys.getenv("GITHUB_BASE_REF"))
+      new_bm <- dplyr::bind_rows(reference, new_bm)
+      stopifnot(nrow(new_bm) == 2)
+      diff_in_percent <- round(100 * diff(new_bm$p50) / new_bm$p50[1])
+      diff_in_percent <- ifelse(diff_in_percent > 0,
+        paste0("+", diff_in_percent),
+        diff_in_percent
+      )
+      pr_comment <- glue::glue("* {name}: {round(new_bm$p50[1], 3)} -> {round(new_bm$p50[2], 3)} ({diff_in_percent}%)")
+      cat(pr_comment, file = "pr-comment/info.txt", sep = "\n", append = TRUE)
+>>>>>>> show + if positive
     }
   }
   new_bm$branch <- factor(new_bm$expression)

--- a/bench/01-declarations.R
+++ b/bench/01-declarations.R
@@ -27,8 +27,8 @@ plot_against_base <- function(new_bm,
         new_bm <- dplyr::bind_rows(reference, new_bm)
         stopifnot(nrow(new_bm) == 2)
         diff_in_percent <- round(100 * diff(new_bm$p50) / new_bm$p50[1])
-        pr_comment <- glue::glue("* {name}: {new_bm$p50[1]} -> {new_bm$p50[2]} ({diff_in_percent}%)\n")
-        cat(pr_comment, file = "pr-comment/info.txt", append = TRUE)
+        pr_comment <- glue::glue("* {name}: {round(new_bm$p50[1], 3)} -> {round(new_bm$p50[2], 3)} ({diff_in_percent}%)")
+        cat(pr_comment, file = "pr-comment/info.txt", sep = "\n", append = TRUE)
       }
     }
   }


### PR DESCRIPTION
Don't convert transformers to character. We have version and name, this is sufficient. Goal is also to see if this is reflected in continuous benchmarking.
dccfa
* cache_appyling: 0.095 -> 0.04 (-58%) 
* cache_recording: 1.258 -> 1.106 (-12%) 
* without_cache: 3.17 -> 3.319 (5%)

6535ba1 (wait: 0.003)
* cache_appyling: 0.095 -> 0.039 (-59%)
* cache_recording: 1.258 -> 1.073 (-15%)
* without_cache: 3.17 -> 3.33 (+5%)

7cac0f1 (wait: 0.004)
* cache_appyling: 0.095 -> 0.047 (-51%)
* cache_recording: 1.258 -> 1.324 (+5%)
* without_cache: 3.17 -> 3.98 (+26%)

75176a6
* cache_appyling: 0.105 -> 0.038 (-64%)
* cache_recording: 1.371 -> 1.085 (-21%)
* without_cache: 3.632 -> 3.555 (-2%)

Major speed improvements are expected for `cache_appyling` and `cache_recording`, but `without_cache` should not change at all but is 5% slower.