### PR TITLE
use magrittr 2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ BugReports: https://github.com/r-lib/styler/issues
 Imports: 
     backports (>= 1.1.0),
     cli (>= 1.1.0),
-    magrittr (>= 1.5.0.9000),
+    magrittr (>= 2.0.0),
     purrr (>= 0.2.3),
     R.cache (>= 0.14.0),
     rematch2 (>= 2.0.1),
@@ -41,8 +41,6 @@ Suggests:
     testthat (>= 2.1.0)
 VignetteBuilder: 
     knitr
-Remotes: 
-    tidyverse/magrittr
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ BugReports: https://github.com/r-lib/styler/issues
 Imports: 
     backports (>= 1.1.0),
     cli (>= 1.1.0),
-    magrittr (>= 1.0.1),
+    magrittr (>= 1.5.0.9000),
     purrr (>= 0.2.3),
     R.cache (>= 0.14.0),
     rematch2 (>= 2.0.1),
@@ -41,6 +41,8 @@ Suggests:
     testthat (>= 2.1.0)
 VignetteBuilder: 
     knitr
+Remotes: 
+    tidyverse/magrittr
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace",


### PR DESCRIPTION
Check how this affects speed. Local benchmarks showed ~ 8.1% diff (#664). 

Let's see remote benchmarks
```r
> (4 - 3.7) / 3.7
[1] 0.08108108
```
Ok, pretty close!


* cache_appyling: 0.031 -> 0.029 (-9%)
* cache_recording: 1.078 -> 0.966 (-10%)
* without_cache: 3.162 -> 2.834 (-10%)
