### PR TITLE
use is.character over inherits(character)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@
 - empty lines are now removed between pipes (#645).
 - overhaul pgkdown site: Add search (#623), group function in Reference (#625).
 - always strip trailing spaces and make cache insensitive to it (#626).
+- `style_text()` can now style all input that `is.character()`, not just if it 
+  inherits from classes `character`, `utf8` or `vertical` (#693).
 - minor documentation improvements (#643, #618, #614, #677, #651, #667, #672, 
   #687).
 - The internal `create_tree()` only used in testing of styler now works when the 

--- a/R/io.R
+++ b/R/io.R
@@ -75,7 +75,7 @@ read_utf8 <- function(path) {
     warning = function(w) w,
     error = function(e) e
   )
-  if (inherits(out, "character")) {
+  if (is.character(out)) {
     list(
       text = out,
       missing_EOF_line_break = FALSE

--- a/R/vertical.R
+++ b/R/vertical.R
@@ -5,7 +5,7 @@
 #' @param x A character vector or an object of class "vertical".
 #' @keywords internal
 construct_vertical <- function(x) {
-  stopifnot(inherits(x, what = c("utf8", "character", "vertical")))
+  stopifnot(is.character(x) || inherits(x, what = c("utf8", "vertical")))
   structure(x, class = "vertical")
 }
 

--- a/R/vertical.R
+++ b/R/vertical.R
@@ -5,7 +5,7 @@
 #' @param x A character vector or an object of class "vertical".
 #' @keywords internal
 construct_vertical <- function(x) {
-  stopifnot(is.character(x) || inherits(x, what = c("utf8", "vertical")))
+  stopifnot(is.character(x))
   structure(x, class = "vertical")
 }
 


### PR DESCRIPTION
Ran into this issue:

```
file.create(tmp <- tempfile())
l = xfun::file_string(tmp)
is.character(l)
# [1] TRUE
inherits(l, 'character')
# [2] FALSE
styler::style_text(l)
# Error in construct_vertical(styled_text) : 
#   inherits(x, what = c("utf8", "character", "vertical")) is not TRUE
```

After this PR:

```
styler::style_text(l)

Warning message:
Text to style did not contain any tokens. Returning empty string. 
```

I also filed this with `xfun`: https://github.com/yihui/xfun/pull/41 but I do think `is.character` is probably preferable anyway.

LMK if there's any test to add