### PR TITLE
Prepare for multi-file in and output

### DIFF
--- a/R/testing-public-api.R
+++ b/R/testing-public-api.R
@@ -1,10 +1,11 @@
 #' Capture and post-process the output of `style_file` without causing side
 #' effects
 #'
-#' @param file_in A vector passed to [testthat_file()] to construct the path
+#' @param file_in A vector with paths relative to `tests/testthat` the path
 #'   to the reference file.
 #' @return
-#' A character vector with the captured output of [style_file()] called on
+#' A list. Each element is a character vector with the captured output of
+#' [style_file()] called on
 #' `file_in` ran in a temp dir to avoid side effects on the input file (because
 #' the next time the test would ran, the file would not need styling). The
 #' styling is carried out with a temporary working directory change to keep
@@ -16,13 +17,8 @@
 #' how many characters the path of the temporary directory has.
 #' @importFrom utils capture.output
 #' @keywords internal
-catch_style_file_output <- function(file_in = c(
-                                      "public-api",
-                                      "xyzdir-dirty",
-                                      "dirty-sample-with-scope-tokens.R"
-                                    ),
-                                    encoding) {
-  file_in <- do.call(testthat_file, as.list(file_in))
+catch_style_file_output <- function(file_in, encoding) {
+  file_in <- testthat_file(file_in)
   temp_path <- copy_to_tempdir(file_in)
   raw_output <- withr::with_dir(
     dirname(temp_path),

--- a/R/testing-public-api.R
+++ b/R/testing-public-api.R
@@ -17,7 +17,7 @@
 #' how many characters the path of the temporary directory has.
 #' @importFrom utils capture.output
 #' @keywords internal
-catch_style_file_output <- function(file_in, encoding) {
+catch_style_file_output <- function(file_in) {
   file_in <- testthat_file(file_in)
   temp_path <- copy_to_tempdir(file_in)
   raw_output <- withr::with_dir(

--- a/man/catch_style_file_output.Rd
+++ b/man/catch_style_file_output.Rd
@@ -5,7 +5,7 @@
 \title{Capture and post-process the output of \code{style_file} without causing side
 effects}
 \usage{
-catch_style_file_output(file_in, encoding)
+catch_style_file_output(file_in)
 }
 \arguments{
 \item{file_in}{A vector with paths relative to \code{tests/testthat} the path

--- a/man/catch_style_file_output.Rd
+++ b/man/catch_style_file_output.Rd
@@ -5,17 +5,15 @@
 \title{Capture and post-process the output of \code{style_file} without causing side
 effects}
 \usage{
-catch_style_file_output(
-  file_in = c("public-api", "xyzdir-dirty", "dirty-sample-with-scope-tokens.R"),
-  encoding
-)
+catch_style_file_output(file_in, encoding)
 }
 \arguments{
-\item{file_in}{A vector passed to \code{\link[=testthat_file]{testthat_file()}} to construct the path
+\item{file_in}{A vector with paths relative to \code{tests/testthat} the path
 to the reference file.}
 }
 \value{
-A character vector with the captured output of \code{\link[=style_file]{style_file()}} called on
+A list. Each element is a character vector with the captured output of
+\code{\link[=style_file]{style_file()}} called on
 \code{file_in} ran in a temp dir to avoid side effects on the input file (because
 the next time the test would ran, the file would not need styling). The
 styling is carried out with a temporary working directory change to keep

--- a/tests/testthat/test-public_api.R
+++ b/tests/testthat/test-public_api.R
@@ -153,7 +153,7 @@ test_that("messages (via cat()) of style_file are correct", {
       list(cli.unicode = encoding == "utf8"),
       {
         # Message if scope > line_breaks and code changes
-        output <- catch_style_file_output(c(
+        output <- catch_style_file_output(file.path(
           "public-api",
           "xyzdir-dirty",
           "dirty-sample-with-scope-tokens.R"
@@ -168,7 +168,7 @@ test_that("messages (via cat()) of style_file are correct", {
         )
 
         # No message if scope > line_breaks and code does not change
-        output <- catch_style_file_output(c(
+        output <- catch_style_file_output(file.path(
           "public-api", "xyzdir-dirty", "clean-sample-with-scope-tokens.R"
         ), encoding = encoding)
         expect_known_value(
@@ -181,7 +181,7 @@ test_that("messages (via cat()) of style_file are correct", {
         )
 
         # No message if scope <= line_breaks even if code is changed.
-        output <- catch_style_file_output(c(
+        output <- catch_style_file_output(file.path(
           "public-api", "xyzdir-dirty", "dirty-sample-with-scope-spaces.R"
         ), encoding = encoding)
         expect_known_value(
@@ -202,7 +202,7 @@ test_that("Messages can be suppressed", {
     withr::with_options(
       list(cli.unicode = encoding == "utf8", styler.quiet = TRUE),
       {
-        output <- catch_style_file_output(c(
+        output <- catch_style_file_output(file.path(
           "public-api", "xyzdir-dirty", "dirty-sample-with-scope-spaces.R"
         ), encoding = encoding)
         expect_equal(output, character(0))

--- a/tests/testthat/test-public_api.R
+++ b/tests/testthat/test-public_api.R
@@ -157,7 +157,7 @@ test_that("messages (via cat()) of style_file are correct", {
           "public-api",
           "xyzdir-dirty",
           "dirty-sample-with-scope-tokens.R"
-        ), encoding = encoding)
+        ))
         expect_known_value(
           output,
           testthat_file(paste0(
@@ -170,7 +170,7 @@ test_that("messages (via cat()) of style_file are correct", {
         # No message if scope > line_breaks and code does not change
         output <- catch_style_file_output(file.path(
           "public-api", "xyzdir-dirty", "clean-sample-with-scope-tokens.R"
-        ), encoding = encoding)
+        ))
         expect_known_value(
           output,
           testthat_file(paste0(
@@ -183,7 +183,7 @@ test_that("messages (via cat()) of style_file are correct", {
         # No message if scope <= line_breaks even if code is changed.
         output <- catch_style_file_output(file.path(
           "public-api", "xyzdir-dirty", "dirty-sample-with-scope-spaces.R"
-        ), encoding = encoding)
+        ))
         expect_known_value(
           output,
           testthat_file(paste0(
@@ -198,17 +198,15 @@ test_that("messages (via cat()) of style_file are correct", {
 })
 
 test_that("Messages can be suppressed", {
-  for (encoding in ls_testable_encodings()) {
     withr::with_options(
-      list(cli.unicode = encoding == "utf8", styler.quiet = TRUE),
+      list(styler.quiet = TRUE),
       {
         output <- catch_style_file_output(file.path(
           "public-api", "xyzdir-dirty", "dirty-sample-with-scope-spaces.R"
-        ), encoding = encoding)
+        ))
         expect_equal(output, character(0))
       }
     )
-  }
 })
 
 context("public API - Rmd in style_dir()")


### PR DESCRIPTION
This makes `catch_style_file_output()` ready to work with multiple paths, remove unintuitive defaults and a redundant `encoding` argument.