### PR TITLE
Fix style_selection when styler.save_after_styling is not set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,7 @@
   the R option `styler.save_after_styling` to control if a file is saved after 
   styling with the RStudio Addin. Note than in RStudio >= 1.3.0, you can 
   auto-save edits in general (Code -> Saving -> Auto-Save), e.g. on idle editor 
-  or focus loss, so this feature becomes less relevant. (#631).
+  or focus loss, so this feature becomes less relevant (#631, #726).
 - blank lines in function calls and headers are now removed, for the former only 
   when there are no comments before or after the blank line (#629, #630, #635, 
   #723).

--- a/R/addins.R
+++ b/R/addins.R
@@ -133,7 +133,7 @@ style_selection <- function() {
     context$selection[[1]]$range, paste0(c(out, if (context$selection[[1]]$range$end[2] == 1) ""), collapse = "\n"),
     id = context$id
   )
-  if (getOption("styler.save_after_styling") == TRUE && context$path != "") {
+  if (save_after_styling_is_active() == TRUE && context$path != "") {
     invisible(rstudioapi::documentSave(context$id))
   }
 }


### PR DESCRIPTION
don't check option as most likely unset. Once env var is removed, we can set it in .onLoad