### PR TITLE
Fix `apply_stylerignore()` for unknown number of cases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@
   style guide (#722, #727).
 - unary `+` before a function call does not give an error anymore, as before 
   version 1.3.0 (#697).
+- certain combinations of `stylerignore` markers and cached expressions now 
+  don't give an error anymore (#738).
 - cache is now correctly invalidated when style guide arguments change (#647).
 - empty lines are now removed between pipes and assignments (#645, #710).
 - overhaul pgkdown site: Add search (#623), group function in Reference (#625).

--- a/R/stylerignore.R
+++ b/R/stylerignore.R
@@ -117,14 +117,16 @@ apply_stylerignore <- function(flattened_pd) {
   flattened_pd <- merge(
     flattened_pd[!(to_ignore & not_first), ],
     env_current$stylerignore[, colnames_required_apply_stylerignore],
-    by.x = "pos_id", by.y = "first_pos_id_in_segment", all.x = TRUE
+    by.x = "pos_id", by.y = "first_pos_id_in_segment", all.x = TRUE,
+    sort = FALSE
   ) %>%
     as_tibble()
   flattened_pd %>%
     stylerignore_consolidate_col("lag_newlines") %>%
     stylerignore_consolidate_col("lag_spaces") %>%
     stylerignore_consolidate_col("text") %>%
-    stylerignore_consolidate_col("pos_id", "pos_id", "pos_id_")
+    stylerignore_consolidate_col("pos_id", "pos_id", "pos_id_") %>%
+    arrange_pos_id()
 }
 
 #' Consolidate columns after a merge
@@ -143,7 +145,6 @@ stylerignore_consolidate_col <- function(flattened_pd,
                                          col,
                                          col_x = paste0(col, ".x"),
                                          col_y = paste0(col, ".y")) {
-
   flattened_pd[[col]] <- ifelse(is.na(flattened_pd[[col_y]]),
     flattened_pd[[col_x]],
     flattened_pd[[col_y]]


### PR DESCRIPTION
Order according to pos_id after merge in `apply_stylerignore()`, closes #737.