### PR TITLE
Complete doc overhaul

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,10 +11,10 @@ Authors@R:
              family = "Walthert",
              role = c("cre", "aut"),
              email = "lorenz.walthert@icloud.com"))
-Description: Pretty-prints R code without changing the user's
-    formatting intent.
+Description: Pretty-prints R code without changing the user's formatting
+    intent.
 License: GPL-3
-URL: https://github.com/r-lib/styler
+URL: https://github.com/r-lib/styler, https://styler.r-lib.org
 BugReports: https://github.com/r-lib/styler/issues
 Imports: 
     backports (>= 1.1.0),
@@ -44,8 +44,8 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: true
-Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace",
-    "collate", "pkgapi::api_roclet"))
+Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate",
+    "pkgapi::api_roclet"))
 RoxygenNote: 7.1.1
 Collate: 
     'addins.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,9 @@
 
 ## Major changes
 
-
+- Documentation overhaul: New README, new "Get started" pkgdown page, new 
+  vignettes on `strict = FALSE`, `adoption` renamed to 
+  `third-party integrations`, minor other consistency edits.
 - The environment variable `save_after_styling` is deprecated in favor of 
   the R option `styler.save_after_styling` to control if a file is saved after 
   styling with the RStudio Addin. Note than in RStudio >= 1.3.0, you can 

--- a/R/nest.R
+++ b/R/nest.R
@@ -154,8 +154,10 @@ find_pos_id_to_keep <- function(pd) {
 
 #' Turn off styling for parts of the code
 #'
-#' Using stylerignore markers, you can temporarily turn off styler. See a
-#' few illustrative examples below.
+#' Using stylerignore markers, you can temporarily turn off styler. Beware that
+#' for `styler > 1.2.0`, some alignment is
+#' [detected by styler](https://styler.r-lib.org/articles/detect-alignment.html),
+#' making stylerignore redundant. See a few illustrative examples below.
 #' @details
 #' Styling is on by default when you run styler.
 #'
@@ -200,7 +202,13 @@ find_pos_id_to_keep <- function(pd) {
 #'   "
 #' )
 #' }
-#'
+#' # some alignment of code is detected, so you don't need to use stylerignore
+#' style_text(
+#'   "call(
+#'     xyz =  3,
+#'     x   = 11
+#'   )"
+#' )
 NULL
 
 

--- a/R/style-guides.R
+++ b/R/style-guides.R
@@ -278,12 +278,10 @@ tidyverse_style <- function(scope = "tokens",
 #'   should correspond to the version of the R package that exports the
 #'   style guide.
 #' @param more_specs_style_guide Named vector (coercible to character)
-#'   specifying arguments `args` in
-#'   `transformer <- list(t1 = purrr::partial(f, arg)` because when
-#'   such functions are converted to characters in [styler::cache_make_key()],
-#'   they will yield generic code and we loose the specific value of `arg` (see
-#'   [styler::cache_make_key()]), even when unquoting these inputs with `!!`
-#'   beforehand in `purrr::partial()`.
+#'   with all arguments passed to the style guide and used for cache
+#'   invalidation. You can easily capture them in your style guide function
+#'   declaration with `as.list(environment())` (compare source code of
+#'   `tidyverse_style()`).
 #' @param transformers_drop A list specifying under which conditions
 #'   transformer functions can be dropped since they have no effect on the
 #'   code to format, most easily constructed with

--- a/R/ui-caching.R
+++ b/R/ui-caching.R
@@ -22,12 +22,10 @@ cache_clear <- function(cache_name = NULL, ask = TRUE) {
 
 #' Remember the past to be quicker in the future
 #'
-#' Caching makes styler faster on repeated styling. It does not cache input
-#' but output code. That means if you style code that already complies to a
+#' Caching makes styler faster on repeated styling and is shared across all APIs
+#' (e.g. `style_text()` and Addin).
+#' That means if you style code that already complies to a
 #' style guide and you have previously styled that code, it will be quicker.
-#' Code is cached by expression and the cache is shared across all APIs (e.g.
-#' `style_text()` and Addin).
-#'
 #' @section Manage the cache:
 #' See [cache_info()],[cache_activate()] or [cache_clear()] for utilities to
 #' manage the cache. You can deactivate it altogether with [cache_deactivate()].
@@ -61,6 +59,11 @@ cache_clear <- function(cache_name = NULL, ask = TRUE) {
 #' versions potentially format code differently. This means after upgrading
 #' styler or a style guide you use, the cache will be re-built.
 #'
+#' @section Mechanism and size:
+#' The cache works by storing hashed output code as a whole and by expression,
+#' which is why it takes zero space on disk (the cache is a directory with
+#' empty files which have the hash of output code as name).
+#'
 #' @section Using a cache for styler in CI/CD:
 #' If you want to set up caching in a CI/CD pipeline, we suggest to set the
 #' `{R.cache}` root path to a directory for which you have the cache enabled as
@@ -69,6 +72,7 @@ cache_clear <- function(cache_name = NULL, ask = TRUE) {
 #' [Travis documentation on caching](https://docs.travis-ci.com/user/caching).
 #'
 #' @name caching
+#' @family cache managers
 NULL
 
 #' Show information about the styler cache

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,9 +2,9 @@
   backports::import(pkgname, "trimws")
   op <- options()
   op.styler <- list(
-    styler.colored_print.vertical = TRUE,
-    styler.cache_name = styler_version,
     styler.addins_style_transformer = "styler::tidyverse_style()",
+    styler.cache_name = styler_version,
+    styler.colored_print.vertical = TRUE,
     styler.ignore_start = "# styler: off",
     styler.ignore_stop = "# styler: on",
     styler.quiet = FALSE,

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,7 +33,7 @@ You can access styler through
 
 * the RStudio Addin as demonstrated below
 * R functions like `style_pkg()`, `style_file()` or `style_text()`
-* various third-party interactions described in `vignette("adoption")`
+* various interactions described in `vignette("third-party-integration")`
 
 
 ```{r, out.width = "650px", echo = FALSE}

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,16 +15,25 @@ knitr::opts_chunk$set(
 ```
 
 # styler
-[![R build status](https://github.com/r-lib/styler/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/styler/actions)
 
-[![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
-[![codecov](https://codecov.io/gh/r-lib/styler/branch/master/graph/badge.svg)](https://codecov.io/gh/r-lib/styler)
-[![cran version](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
+<!-- badges: start -->
+[![R build status](https://github.com/r-lib/styler/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/styler/actions)
+[![Life cycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+[![codecov test coverage](https://codecov.io/gh/r-lib/styler/branch/master/graph/badge.svg)](https://codecov.io/gh/r-lib/styler)
+[![CRAN Status](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
+<!-- badges: end -->
+
+# Overview 
 
 styler formats your code according to the 
-[tidyverse style guide](https://style.tidyverse.org)^[or your custom style guide]
-so you can direct your attention to the content of your code. styler helps to 
+[tidyverse style guide](https://style.tidyverse.org) (or your custom style guide)
+so you can direct your attention to the content of your code. It helps to 
 keep the coding style consistent across projects and facilitate collaboration. 
+You can access styler through 
+
+* the RStudio Addin as demonstrated below,
+* R functions like `style_pkg()`, `style_file()` or `style_text()`.
+* various third-party interactions described in `vignette("adoption")`
 
 
 ```{r, out.width = "650px", echo = FALSE}
@@ -60,3 +69,5 @@ The following online docs are available:
 - [latest CRAN release](https://styler.r-lib.org).
 
 - [GitHub development version](https://styler.r-lib.org/dev).
+
+*** 

--- a/README.Rmd
+++ b/README.Rmd
@@ -31,8 +31,8 @@ so you can direct your attention to the content of your code. It helps to
 keep the coding style consistent across projects and facilitate collaboration. 
 You can access styler through 
 
-* the RStudio Addin as demonstrated below,
-* R functions like `style_pkg()`, `style_file()` or `style_text()`.
+* the RStudio Addin as demonstrated below
+* R functions like `style_pkg()`, `style_file()` or `style_text()`
 * various third-party interactions described in `vignette("adoption")`
 
 
@@ -57,9 +57,9 @@ remotes::install_github("r-lib/styler")
 ```
 
 If you don't use styler interactively (i.e. not from the R prompt or RStudio
-Addin), make sure you authorize `{R.cache}` once to set up a permanent cache. If
-you use it interactively, you will be asked to grant this permission once. See
-`?caching` for details.
+Addin), make sure you authorize the R package R.cache once to set up a permanent 
+cache. If you use it interactively, you will be asked to grant this permission 
+once. See `?caching` for details.
 
 
 ## Documentation
@@ -69,5 +69,3 @@ The following online docs are available:
 - [latest CRAN release](https://styler.r-lib.org).
 
 - [GitHub development version](https://styler.r-lib.org/dev).
-
-*** 

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,7 +1,7 @@
 ---
 output:
   github_document:
-    html_preview: false
+    html_preview: true
 ---
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
@@ -15,25 +15,22 @@ knitr::opts_chunk$set(
 ```
 
 # styler
+[![R build status](https://github.com/r-lib/styler/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/styler/actions)
 
-[![Build
-Status](https://travis-ci.org/r-lib/styler.svg?branch=master)](https://travis-ci.org/r-lib/styler)
-[![AppVeyor Build
-Status](https://ci.appveyor.com/api/projects/status/github/r-lib/styler?branch=master&svg=true)](https://ci.appveyor.com/project/r-lib/styler)
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
 [![codecov](https://codecov.io/gh/r-lib/styler/branch/master/graph/badge.svg)](https://codecov.io/gh/r-lib/styler)
-[![cran
-version](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
+[![cran version](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
 
-The goal of styler is to provide non-invasive pretty-printing of R source code
-while adhering to the [tidyverse](https://style.tidyverse.org) formatting rules.
-styler can be customized to format code according to other style guides too.
+styler formats your code according to the 
+[tidyverse style guide](https://style.tidyverse.org)^[or your custom style guide]
+so you can direct your attention to the content of your code. styler helps to 
+keep the coding style consistent across projects and facilitate collaboration. 
 
-The following online docs are available:
 
-- [latest CRAN release](https://styler.r-lib.org).
+```{r, out.width = "650px", echo = FALSE}
+knitr::include_graphics("https://raw.githubusercontent.com/lorenzwalthert/some_raw_data/master/styler_0.1.gif")
+```
 
-- [GitHub development version](https://styler.r-lib.org/dev).
 
 ## Installation
 
@@ -43,12 +40,6 @@ You can install the package from CRAN.
 install.packages("styler")
 ```
 
-If you don't use styler interactively (i.e. not from the R prompt or RStudio 
-Addin), make sure you authorize `{R.cache}` once to set up a permanent cache. 
-If you use it interactively, you will be asked to grant this permission once.
-See `?caching` for details.
-
-
 Or get the development version from GitHub:
 
 ```{r, eval = FALSE}
@@ -56,133 +47,16 @@ Or get the development version from GitHub:
 remotes::install_github("r-lib/styler")
 ```
 
-## API
+If you don't use styler interactively (i.e. not from the R prompt or RStudio
+Addin), make sure you authorize `{R.cache}` once to set up a permanent cache. If
+you use it interactively, you will be asked to grant this permission once. See
+`?caching` for details.
 
-You can style a simple character vector of code with `style_text()`:
 
-```{r}
-library("styler")
-ugly_code <- "a=function( x){1+1}           "
-style_text(ugly_code)
-```
+## Documentation
 
-There are a few variants of `style_text()`:
+The following online docs are available:
 
-* `style_file()` styles .R, .Rmd .Rnw and .Rprofile, files.
+- [latest CRAN release](https://styler.r-lib.org).
 
-* `style_dir()` styles all .R and/or .Rmd files in a directory.
-
-* `style_pkg()` styles the source files of an R package.
-
-* RStudio Addins for styling the active file, styling the current package and
-  styling the highlighted code region.
-
-```{r, out.width = "650px", echo = FALSE}
-knitr::include_graphics("https://raw.githubusercontent.com/lorenzwalthert/some_raw_data/master/styler_0.1.gif")
-```
-
-## Configuration
-
-You can decide on the level of invasiveness with the scope argument. You can
-style:
-
-* just spaces.
-
-* spaces and indention.
-
-* spaces, indention and line breaks.
-
-* spaces, indention, line breaks and tokens.
-
-```{r}
-ugly_code <- "a=function( x){1+1}           "
-style_text(ugly_code, scope = "spaces")
-```
-
-Note that compared to the default used above `scope = "tokens"`:
-
-* no line breaks were added.
-
-* `<-` was not replaced with `=`.
-
-While spaces still got styled (around `=` in `(x)`).
-
-This was just the tip of the iceberg. To learn more about customization options
-with the tidyverse style guide, see the [help file for
-`tidyverse_style](https://styler.r-lib.org/reference/tidyverse_style.html) for a
-quick overview or the [introductory
-vignette](https://styler.r-lib.org/articles/introducing_styler.html).
-
-## Features
-
-* style roxygen2 code examples.
-
-* do not re-style [deliberate code
-  alignment](https://styler.r-lib.org/articles/detect-alignment.html).
-
-* [ignore some lines](https://styler.r-lib.org/dev/reference/stylerignore.html)
-  for styling.
-
-* [cache styled
-  expressions](https://styler.r-lib.org/dev/reference/caching.html) for speed.
-
-## Adaption of styler
-
-styler functionality is made available through other tools, most notably
-
-* as a pre-commit hook `style-files` in
-  https://github.com/lorenzwalthert/precommit
-
-* `usethis::use_tidy_style()` styles your project according to the tidyverse
-  style guide.
-
-* via commenting a PR on GitHub with `\style` when the [GitHub
-  Action](https://github.com/features/actions) [*Tidyverse
-  CI*](https://github.com/r-lib/actions/tree/master/examples#tidyverse-ci-workflow)
-  is used. The most convenient way to set this up is via
-  [`usethis::use_tidy_github_actions()`](https://usethis.r-lib.org/reference/tidyverse.html).
-
-* `reprex::reprex(style = TRUE)` to prettify reprex code before printing. To
-  permanently use `style = TRUE` without specifying it every time, you can add
-  the following line to your `.Rprofile` (via `usethis::edit_r_profile()`):
-  `options(reprex.styler = TRUE)`.
-
-* you can pretty-print your R code in RMarkdown reports without having styler
-  modifying the source. This feature is implemented as a code chunk option in
-  knitr. use `tidy = "styler"` in the header of a code chunks (e.g. ` ```{r
-  name-of-the-chunk, tidy = "styler"}`), or `knitr::opts_chunk$set(tidy =
-  "styler")` at the top of your RMarkdown script.
-
-* Adding styler as a fixer to the [ale
-  Plug-in](https://github.com/w0rp/ale/pull/2401#issuecomment-485942966) for
-  VIM.
-
-* pretty-printing of [drake](https://github.com/ropensci/drake) workflow data
-  frames with `drake::drake_plan_source()`.
-
-* Adding styler with
-  [emacs-format-all-the-code](https://github.com/lassik/emacs-format-all-the-code)
-  for Emacs.
-
-## Further resources
-
-* The official [web documentation](https://styler.r-lib.org/) of styler,
-  containing various vignettes function documentation as well as a change-log.
-
-* The wiki of [Google Summer of Code
-  2017](https://github.com/rstats-gsoc/gsoc2017/wiki/Noninvasive-source-code-formatting)
-  or the [pkgdown](https://r-lib.github.io/styler/) page contain information
-  related to the initial development phase during Google Summer of Code 2017.
-
-## Contributing
-
-Please have a look at `CONTRIBUTING.md`, in particular, make sure to use the 
-pre-commit hooks and if you skip a hook, describe why in the PR. 
-See the `{precommit}` [README.md](https://github.com/lorenzwalthert/precommit) 
-on how to install the pre-commit framework and the R package on your system and 
-then run
-```{r, eval = FALSE}
-precommit::use_precommit()
-```
-
-to make sure the hooks are activated in your local styler clone.
+- [GitHub development version](https://styler.r-lib.org/dev).

--- a/README.md
+++ b/README.md
@@ -3,25 +3,20 @@
 
 # styler
 
-[![Build
-Status](https://travis-ci.org/r-lib/styler.svg?branch=master)](https://travis-ci.org/r-lib/styler)
-[![AppVeyor Build
-Status](https://ci.appveyor.com/api/projects/status/github/r-lib/styler?branch=master&svg=true)](https://ci.appveyor.com/project/r-lib/styler)
+[![R build
+status](https://github.com/r-lib/styler/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/styler/actions)
+
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
 [![codecov](https://codecov.io/gh/r-lib/styler/branch/master/graph/badge.svg)](https://codecov.io/gh/r-lib/styler)
 [![cran
 version](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
 
-The goal of styler is to provide non-invasive pretty-printing of R
-source code while adhering to the
-[tidyverse](https://style.tidyverse.org) formatting rules. styler can be
-customized to format code according to other style guides too.
+styler formats your code according to the [tidyverse style
+guide](https://style.tidyverse.org)[1] so you can direct your attention
+to the content of your code. styler helps to keep the coding style
+consistent across projects and facilitate collaboration.
 
-The following online docs are available:
-
-  - [latest CRAN release](https://styler.r-lib.org).
-
-  - [GitHub development version](https://styler.r-lib.org/dev).
+<img src="https://raw.githubusercontent.com/lorenzwalthert/some_raw_data/master/styler_0.1.gif" width="650px" />
 
 ## Installation
 
@@ -31,11 +26,6 @@ You can install the package from CRAN.
 install.packages("styler")
 ```
 
-If you don’t use styler interactively (i.e. not from the R prompt or
-RStudio Addin), make sure you authorize `{R.cache}` once to set up a
-permanent cache. If you use it interactively, you will be asked to grant
-this permission once. See `?caching` for details.
-
 Or get the development version from GitHub:
 
 ``` r
@@ -43,144 +33,17 @@ Or get the development version from GitHub:
 remotes::install_github("r-lib/styler")
 ```
 
-## API
+If you don’t use styler interactively (i.e. not from the R prompt or
+RStudio Addin), make sure you authorize `{R.cache}` once to set up a
+permanent cache. If you use it interactively, you will be asked to grant
+this permission once. See `?caching` for details.
 
-You can style a simple character vector of code with `style_text()`:
+## Documentation
 
-``` r
-library("styler")
-ugly_code <- "a=function( x){1+1}           "
-style_text(ugly_code)
-#> a <- function(x) {
-#>   1 + 1
-#> }
-```
+The following online docs are available:
 
-There are a few variants of `style_text()`:
+-   [latest CRAN release](https://styler.r-lib.org).
 
-  - `style_file()` styles .R, .Rmd .Rnw and .Rprofile, files.
+-   [GitHub development version](https://styler.r-lib.org/dev).
 
-  - `style_dir()` styles all .R and/or .Rmd files in a directory.
-
-  - `style_pkg()` styles the source files of an R package.
-
-  - RStudio Addins for styling the active file, styling the current
-    package and styling the highlighted code region.
-
-<img src="https://raw.githubusercontent.com/lorenzwalthert/some_raw_data/master/styler_0.1.gif" width="650px" />
-
-## Configuration
-
-You can decide on the level of invasiveness with the scope argument. You
-can style:
-
-  - just spaces.
-
-  - spaces and indention.
-
-  - spaces, indention and line breaks.
-
-  - spaces, indention, line breaks and tokens.
-
-<!-- end list -->
-
-``` r
-ugly_code <- "a=function( x){1+1}           "
-style_text(ugly_code, scope = "spaces")
-#> a = function(x) {1 + 1}
-```
-
-Note that compared to the default used above `scope = "tokens"`:
-
-  - no line breaks were added.
-
-  - `<-` was not replaced with `=`.
-
-While spaces still got styled (around `=` in `(x)`).
-
-This was just the tip of the iceberg. To learn more about customization
-options with the tidyverse style guide, see the [help file for
-\`tidyverse\_style](https://styler.r-lib.org/reference/tidyverse_style.html)
-for a quick overview or the [introductory
-vignette](https://styler.r-lib.org/articles/introducing_styler.html).
-
-## Features
-
-  - style roxygen2 code examples.
-
-  - do not re-style [deliberate code
-    alignment](https://styler.r-lib.org/articles/detect-alignment.html).
-
-  - [ignore some
-    lines](https://styler.r-lib.org/dev/reference/stylerignore.html) for
-    styling.
-
-  - [cache styled
-    expressions](https://styler.r-lib.org/dev/reference/caching.html)
-    for speed.
-
-## Adaption of styler
-
-styler functionality is made available through other tools, most notably
-
-  - as a pre-commit hook `style-files` in
-    <https://github.com/lorenzwalthert/precommit>
-
-  - `usethis::use_tidy_style()` styles your project according to the
-    tidyverse style guide.
-
-  - via commenting a PR on GitHub with `\style` when the [GitHub
-    Action](https://github.com/features/actions) [*Tidyverse
-    CI*](https://github.com/r-lib/actions/tree/master/examples#tidyverse-ci-workflow)
-    is used. The most convenient way to set this up is via
-    [`usethis::use_tidy_github_actions()`](https://usethis.r-lib.org/reference/tidyverse.html).
-
-  - `reprex::reprex(style = TRUE)` to prettify reprex code before
-    printing. To permanently use `style = TRUE` without specifying it
-    every time, you can add the following line to your `.Rprofile` (via
-    `usethis::edit_r_profile()`): `options(reprex.styler = TRUE)`.
-
-  - you can pretty-print your R code in RMarkdown reports without having
-    styler modifying the source. This feature is implemented as a code
-    chunk option in knitr. use `tidy = "styler"` in the header of a code
-    chunks (e.g. ` ```{r name-of-the-chunk, tidy = "styler"} `), or
-    `knitr::opts_chunk$set(tidy = "styler")` at the top of your
-    RMarkdown script.
-
-  - Adding styler as a fixer to the [ale
-    Plug-in](https://github.com/w0rp/ale/pull/2401#issuecomment-485942966)
-    for VIM.
-
-  - pretty-printing of [drake](https://github.com/ropensci/drake)
-    workflow data frames with `drake::drake_plan_source()`.
-
-  - Adding styler with
-    [emacs-format-all-the-code](https://github.com/lassik/emacs-format-all-the-code)
-    for Emacs.
-
-## Further resources
-
-  - The official [web documentation](https://styler.r-lib.org/) of
-    styler, containing various vignettes function documentation as well
-    as a change-log.
-
-  - The wiki of [Google Summer of Code
-    2017](https://github.com/rstats-gsoc/gsoc2017/wiki/Noninvasive-source-code-formatting)
-    or the [pkgdown](https://r-lib.github.io/styler/) page contain
-    information related to the initial development phase during Google
-    Summer of Code 2017.
-
-## Contributing
-
-Please have a look at `CONTRIBUTING.md`, in particular, make sure to use
-the pre-commit hooks and if you skip a hook, describe why in the PR. See
-the `{precommit}`
-[README.md](https://github.com/lorenzwalthert/precommit) on how to
-install the pre-commit framework and the R package on your system and
-then run
-
-``` r
-precommit::use_precommit()
-```
-
-to make sure the hooks are activated in your local styler clone.
+[1] or your custom style guide

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ can direct your attention to the content of your code. It helps to keep
 the coding style consistent across projects and facilitate
 collaboration. You can access styler through
 
--   the RStudio Addin as demonstrated below,
--   R functions like `style_pkg()`, `style_file()` or `style_text()`.
+-   the RStudio Addin as demonstrated below
+-   R functions like `style_pkg()`, `style_file()` or `style_text()`
 -   various third-party interactions described in `vignette("adoption")`
 
 <img src="https://raw.githubusercontent.com/lorenzwalthert/some_raw_data/master/styler_0.1.gif" width="650px" />
@@ -45,9 +45,9 @@ remotes::install_github("r-lib/styler")
 ```
 
 If you don’t use styler interactively (i.e. not from the R prompt or
-RStudio Addin), make sure you authorize `{R.cache}` once to set up a
-permanent cache. If you use it interactively, you will be asked to grant
-this permission once. See `?caching` for details.
+RStudio Addin), make sure you authorize the R package R.cache once to
+set up a permanent cache. If you use it interactively, you will be asked
+to grant this permission once. See `?caching` for details.
 
 ## Documentation
 
@@ -56,5 +56,3 @@ The following online docs are available:
 -   [latest CRAN release](https://styler.r-lib.org).
 
 -   [GitHub development version](https://styler.r-lib.org/dev).
-
-------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -3,18 +3,29 @@
 
 # styler
 
+<!-- badges: start -->
+
 [![R build
 status](https://github.com/r-lib/styler/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/styler/actions)
+[![Life cycle:
+stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+[![codecov test
+coverage](https://codecov.io/gh/r-lib/styler/branch/master/graph/badge.svg)](https://codecov.io/gh/r-lib/styler)
+[![CRAN
+Status](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
+<!-- badges: end -->
 
-[![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
-[![codecov](https://codecov.io/gh/r-lib/styler/branch/master/graph/badge.svg)](https://codecov.io/gh/r-lib/styler)
-[![cran
-version](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
+# Overview
 
 styler formats your code according to the [tidyverse style
-guide](https://style.tidyverse.org)[1] so you can direct your attention
-to the content of your code. styler helps to keep the coding style
-consistent across projects and facilitate collaboration.
+guide](https://style.tidyverse.org) (or your custom style guide) so you
+can direct your attention to the content of your code. It helps to keep
+the coding style consistent across projects and facilitate
+collaboration. You can access styler through
+
+-   the RStudio Addin as demonstrated below,
+-   R functions like `style_pkg()`, `style_file()` or `style_text()`.
+-   various third-party interactions described in `vignette("adoption")`
 
 <img src="https://raw.githubusercontent.com/lorenzwalthert/some_raw_data/master/styler_0.1.gif" width="650px" />
 
@@ -46,4 +57,4 @@ The following online docs are available:
 
 -   [GitHub development version](https://styler.r-lib.org/dev).
 
-[1] or your custom style guide
+------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ collaboration. You can access styler through
 
 -   the RStudio Addin as demonstrated below
 -   R functions like `style_pkg()`, `style_file()` or `style_text()`
--   various third-party interactions described in `vignette("adoption")`
+-   various interactions described in
+    `vignette("third-party-integration")`
 
 <img src="https://raw.githubusercontent.com/lorenzwalthert/some_raw_data/master/styler_0.1.gif" width="650px" />
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -69,7 +69,7 @@ articles:
   - styler
   - detect-alignment
   - strict
-  - adoption
+  - third-party-integration
 
 - title: Developers
   navbar: Developers

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,6 @@
+home:
+  strip_header: true
+
 reference:
 - title: "Styling API"
   desc: >
@@ -60,15 +63,16 @@ news:
     href: https://lorenzwalthert.netlify.com/post/styler-1-3-0/
 
 articles:
-- title: End-users
-  navbar: End-users
+- title: Get started
+  navbar: ~
   contents:
-  - introducing_styler
+  - styler
   - detect-alignment
+  - strict
+  - adoption
 
 - title: Developers
   navbar: Developers
   contents:
   - caching
   - customizing_styler
-  - performance_improvements

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -56,11 +56,13 @@ expr EQ
 fileext
 filetype
 forcond
+formatter
 funct
 gcc
 getChecksum
 getOption
 getRversion
+ggplot
 github
 gitsum
 GSOC
@@ -69,6 +71,7 @@ href
 http
 https
 icloud
+ifelse
 impl
 infinitively
 initializer
@@ -78,6 +81,7 @@ invasiveness
 io
 ixmypi
 ized
+Jupyterlab
 Kirill
 knitr
 krlmlr

--- a/man/cache_activate.Rd
+++ b/man/cache_activate.Rd
@@ -24,6 +24,7 @@ Helper functions to control the behavior of caching. Simple wrappers around
 \seealso{
 Other cache managers: 
 \code{\link{cache_clear}()},
-\code{\link{cache_info}()}
+\code{\link{cache_info}()},
+\code{\link{caching}}
 }
 \concept{cache managers}

--- a/man/cache_clear.Rd
+++ b/man/cache_clear.Rd
@@ -26,6 +26,7 @@ potentially different with different versions of styler.
 \seealso{
 Other cache managers: 
 \code{\link{cache_activate}()},
-\code{\link{cache_info}()}
+\code{\link{cache_info}()},
+\code{\link{caching}}
 }
 \concept{cache managers}

--- a/man/cache_info.Rd
+++ b/man/cache_info.Rd
@@ -24,6 +24,7 @@ excluded from this displayed size but negligible.
 \seealso{
 Other cache managers: 
 \code{\link{cache_activate}()},
-\code{\link{cache_clear}()}
+\code{\link{cache_clear}()},
+\code{\link{caching}}
 }
 \concept{cache managers}

--- a/man/caching.Rd
+++ b/man/caching.Rd
@@ -4,11 +4,10 @@
 \alias{caching}
 \title{Remember the past to be quicker in the future}
 \description{
-Caching makes styler faster on repeated styling. It does not cache input
-but output code. That means if you style code that already complies to a
+Caching makes styler faster on repeated styling and is shared across all APIs
+(e.g. \code{style_text()} and Addin).
+That means if you style code that already complies to a
 style guide and you have previously styled that code, it will be quicker.
-Code is cached by expression and the cache is shared across all APIs (e.g.
-\code{style_text()} and Addin).
 }
 \section{Manage the cache}{
 
@@ -53,6 +52,13 @@ versions potentially format code differently. This means after upgrading
 styler or a style guide you use, the cache will be re-built.
 }
 
+\section{Mechanism and size}{
+
+The cache works by storing hashed output code as a whole and by expression,
+which is why it takes zero space on disk (the cache is a directory with
+empty files which have the hash of output code as name).
+}
+
 \section{Using a cache for styler in CI/CD}{
 
 If you want to set up caching in a CI/CD pipeline, we suggest to set the
@@ -62,3 +68,10 @@ in config files of CI/CD tools, e.g. see the
 \href{https://docs.travis-ci.com/user/caching}{Travis documentation on caching}.
 }
 
+\seealso{
+Other cache managers: 
+\code{\link{cache_activate}()},
+\code{\link{cache_clear}()},
+\code{\link{cache_info}()}
+}
+\concept{cache managers}

--- a/man/create_style_guide.Rd
+++ b/man/create_style_guide.Rd
@@ -50,12 +50,10 @@ should correspond to the version of the R package that exports the
 style guide.}
 
 \item{more_specs_style_guide}{Named vector (coercible to character)
-specifying arguments \code{args} in
-\verb{transformer <- list(t1 = purrr::partial(f, arg)} because when
-such functions are converted to characters in \code{\link[=cache_make_key]{cache_make_key()}},
-they will yield generic code and we loose the specific value of \code{arg} (see
-\code{\link[=cache_make_key]{cache_make_key()}}), even when unquoting these inputs with \verb{!!}
-beforehand in \code{purrr::partial()}.}
+with all arguments passed to the style guide and used for cache
+invalidation. You can easily capture them in your style guide function
+declaration with \code{as.list(environment())} (compare source code of
+\code{tidyverse_style()}).}
 
 \item{transformers_drop}{A list specifying under which conditions
 transformer functions can be dropped since they have no effect on the

--- a/man/stylerignore.Rd
+++ b/man/stylerignore.Rd
@@ -4,8 +4,10 @@
 \alias{stylerignore}
 \title{Turn off styling for parts of the code}
 \description{
-Using stylerignore markers, you can temporarily turn off styler. See a
-few illustrative examples below.
+Using stylerignore markers, you can temporarily turn off styler. Beware that
+for \verb{styler > 1.2.0}, some alignment is
+\href{https://styler.r-lib.org/articles/detect-alignment.html}{detected by styler},
+making stylerignore redundant. See a few illustrative examples below.
 }
 \details{
 Styling is on by default when you run styler.
@@ -52,5 +54,11 @@ style_text(
   "
 )
 }
-
+# some alignment of code is detected, so you don't need to use stylerignore
+style_text(
+  "call(
+    xyz =  3,
+    x   = 11
+  )"
+)
 }

--- a/vignettes/adoption.Rmd
+++ b/vignettes/adoption.Rmd
@@ -53,5 +53,5 @@ styler functionality is available in other tools, most notably
   frames with `drake::drake_plan_source()`.
 
 Do you know another way to use styler that is not listed here? Please let us know
-by [opening an issue](https://github.com/r-lib/styler/issues), we'll extend the
+by [opening an issue](https://github.com/r-lib/styler/issues) and we'll extend the
 list.

--- a/vignettes/adoption.Rmd
+++ b/vignettes/adoption.Rmd
@@ -52,6 +52,6 @@ styler functionality is available in other tools, most notably
 * for pretty-printing [drake](https://github.com/ropensci/drake) workflow data
   frames with `drake::drake_plan_source()`.
 
-You know another way to use styler that is not listed here? Please let us know,
+Do you know another way to use styler that is not listed here? Please let us know
 by [opening an issue](https://github.com/r-lib/styler/issues), we'll extend the
 list.

--- a/vignettes/adoption.Rmd
+++ b/vignettes/adoption.Rmd
@@ -1,0 +1,57 @@
+---
+title: "Adoption of styler"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Adoption of styler}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+styler functionality is available in other tools, most notably
+
+* as a pre-commit hook `style-files` in
+  <https://github.com/lorenzwalthert/precommit>
+
+* via `usethis::use_tidy_style()` styles your project according to the tidyverse
+  style guide.
+
+* through commenting a PR on GitHub with `\style` when the [GitHub
+  Action](https://github.com/features/actions) [*Tidyverse
+  CI*](https://github.com/r-lib/actions/tree/master/examples#tidyverse-ci-workflow)
+  is used. The most convenient way to set this up is via
+  [`usethis::use_tidy_github_actions()`](https://usethis.r-lib.org/reference/tidyverse.html).
+
+* in `reprex::reprex(..., style = TRUE)` to prettify reprex code before
+  printing. To permanently use `style = TRUE` without specifying it every time,
+  you can add the following line to your `.Rprofile` (via
+  `usethis::edit_r_profile()`): `options(reprex.styler = TRUE)`.
+
+* as a formatter for RMarkdown without modifying the source. This feature is
+  implemented as a code chunk option in knitr. use `tidy = "styler"` in the
+  header of a code chunks (e.g.` ```{r name-of-the-chunk, tidy = "styler"} `),
+  or `knitr::opts_chunk$set(tidy = "styler")` at the top of your RMarkdown
+  script.
+
+* As a fixer to the [ale
+  Plug-in](https://github.com/w0rp/ale/pull/2401#issuecomment-485942966) for
+  VIM.
+
+* in the *format-all* command for Emacs in 
+  [emacs-format-all-the-code](https://github.com/lassik/emacs-format-all-the-code).
+
+* As a [Jupyterlab code
+  formatter](https://jupyterlab-code-formatter.readthedocs.io/en/latest/installation.html#r-code-formatters).
+
+* for pretty-printing [drake](https://github.com/ropensci/drake) workflow data
+  frames with `drake::drake_plan_source()`.
+
+You know another way to use styler that is not listed here? Please let us know,
+by [opening an issue](https://github.com/r-lib/styler/issues), we'll extend the
+list.

--- a/vignettes/caching.Rmd
+++ b/vignettes/caching.Rmd
@@ -2,7 +2,7 @@
 title: "Caching"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{caching}
+  %\VignetteIndexEntry{Caching}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/customizing_styler.Rmd
+++ b/vignettes/customizing_styler.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Customizing styler"
-author: "Lorenz Walthert"
-date: "8/10/2017"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Customizing styler}

--- a/vignettes/introducing_styler.Rmd
+++ b/vignettes/introducing_styler.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "An introduction to styler"
-author: "Lorenz Walthert"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{An introduction to styler}
@@ -9,11 +7,9 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-This vignette introduces the basic functionality of styler and showcases
-how styler applies a few rules of the 
-[tidyverse style guide](http://style.tidyverse.org/index.html) to example code.
-Note that you can create your own style guide and customize styler even further, 
-as described in the vignette "Customizing styler".
+> This is an old vignette superseded by *Get started*. It might be outdated and 
+  is not yet deleted to avoid HTTP 404 errors until re-directs are implemented 
+  in pkgdown: https://github.com/r-lib/pkgdown/issues/1259
 
 ```{r, echo = FALSE}
 knitr::opts_chunk$set(echo = TRUE, comment = "")
@@ -22,98 +18,184 @@ knitr::knit_engines$set(list(
     options$comment <- ""
     knitr::engine_output(
       options,
-      
       c("# Before", options$code),
       c("# After", styler::style_text(options$code))
     )
   }
 ))
-
 ```
 
-It's possible to use different levels of 'invasiveness', as described in the 
-help file for the only style guide implemented so far, which is the 
-[tidyverse style guide](http://style.tidyverse.org/index.html). The style guide 
-in use is passed to the styling function (i.e `style_text()` and friends) via 
-the `style` argument, which defaults to `tidyverse_style`. In addition to this 
-argument, there are further customization options. For example, we can limit 
-ourselves to styling just spacing information by indicating this with the 
-`scope` argument:
+# Entry-points
+
+styler provides the following API to format code:
+
+* `style_file()` styles .R, .Rmd .Rnw and .Rprofile files.
+
+* `style_dir()` styles all .R and/or .Rmd files in a directory.
+
+* `style_pkg()` styles the source files of an R package.
+
+* RStudio Addins for styling the active file, styling the current package and
+  styling the highlighted selection, see `help("styler_addins")`.
+
+Beyond that, styler can be used through other tools documented in the
+`vignette("third-party-integration")`.
+
+### Passing arguments to the style guide
+
+styler separates the abstract definition of a style guide from the application
+of it. That's why you must supply a style guide via `transformers` when
+styling (in case you don't want to rely on the defaults):
 
 ```{r}
-library("styler")
-library("magrittr")
-style_text("a=3; 2", scope = "spaces")
+library(styler)
+style_text("a + b", transformers = tidyverse_style(scope = "indention"))
 ```
 
-Or, on the other extreme of the scale, styling spaces, indention, line breaks 
-and tokens (which is the default):
+The styler API was designed so that you can pass arguments to the style guide
+via the styling function (e.g. `style_file()`) to allow more concise syntax:
+
+```{r, results = 'hide'}
+# equivalent
+style_text("a + b", transformers = tidyverse_style(scope = "indention"))
+style_text("a + b", scope = "indention")
+```
+
+The magic is possible thanks to `...`. See `style_text()` for details.
+
+# Invasiveness 
+
+### `scope`: What to style? 
+
+This argument of `tidyverse_style()` determines the invasiveness of styling. The
+following levels for `scope` are available (in increasing order):
+
+* "none": Performs no transformation at all.
+
+* "spaces": Manipulates spacing between token on the same line.
+
+* "indention": Manipulates the indention, i.e. number of spaces at the beginning
+  of each line.
+
+* "line_breaks": Manipulates line breaks between tokens.
+
+* "tokens": manipulates tokens.
+
+There are two ways to specify the scope of styling.
+
+* As a string: In this case all less invasive scope levels are implied, e.g.
+  `"line_breaks"` includes `"indention"`, `"spaces"`. This is brief and what
+  most users need. This is supported in `styler >= 1.0.0`.
+
+* As vector of class `AsIs`: Each level has to be listed explicitly by wrapping
+  one ore more levels of the scope in `I()`. This offers more granular control
+  at the expense of more verbosity. This is supported in `styler > 1.3.2`.
 
 ```{r}
-style_text("a=3; 2", scope = "tokens")
+# tokens and everything less invasive
+style_text("a=2", scope = "tokens")
+
+# just tokens and indention
+style_text("a=2", scope = I(c("tokens", "indention")))
 ```
 
+As you can see from the output, the assignment operator `=` is replaced with
+`<-` in both cases, but spacing remained unchanged in the second example.
 
-`scope` always includes less-invasive styling than the option chosen, 
-e.g. `scope = "line_breaks"` includes styling spaces and indention in addition 
-to line breaks.
-
-
-We can also choose to style line breaks but not tokens:
-```{r}
-style_text("if(x) {66 } else {a=3}", scope = "line_breaks")
-```
-
-Note that `scope = "spaces"` does not touch indention
-```{r}
-code <- c(
-    "a <- function() { ", 
-    "                a=3", 
-    "}"
-)
-
-style_text(code, scope = "spaces")
-```
-
-But `scope = "indention"` - as the name says - does.
-```{r}
-style_text(code, scope = "indention")
-```
-
+### How `strict` do you want styler to be?
 
 Another option that is helpful to determine the level of 'invasiveness' is
-`strict`. If set to `TRUE`, spaces and line breaks before or after tokens are
-set to either zero or one. However, in some situations this might be undesirable,
-as the following example shows:
-
+`strict` (defaulting to `TRUE`). Some rules won't be applied so strictly with
+`strict = FALSE`, assuming you deliberately formatted things the way they are.
+Please see in `vignette("strict")`. For `styler >= 1.2` alignment in function
+calls is detected and preserved so you don't need `strict = FALSE`, e.g.
 ```{r}
 style_text(
-  "data_frame(
+  "tibble::tibble(
      small  = 2 ,
      medium = 4,#comment without space
      large  = 6
-   )", strict = FALSE
+   )"
 )
 ```
 
-We prefer to keep the equal sign after "small", "medium" and large aligned,
-so we set `strict = FALSE` to set spacing to *at least* one around `=`.
+The details are in `vignette("detect-alignment")`.
 
-Also, spaces before comments are preserved with that option.
+# Ignoring certain lines
+
+You can tell styler to ignore some lines if you want to keep current formatting.
+You can mark whole blocks or inline expressions with `styler: on` and `styler:
+off`:
 
 ```{r}
-style_text(
-  "a <-   'one'   #just one
-   abc <- 'three' # three", 
-  strict = FALSE
+styler::style_text(
+  "
+  #> blocks
+  blibala= 3
+  # styler: off
+  I_have(good+reasons, to = turn_off,
+    styler
+  )
+  # styler: on
+  1+1
+
+  #> inline
+  ignore( this) # styler: off
+  f( ) # not ignored anymore
+"
 )
 ```
+You can also use custom markers as described in 
+`help("stylerignore", package = "styler")`. As described above and in
+`vignette("detect-alignment")`,
+some alignment is recognized and hence, *stylerignore* should not 
+be necessary in that context.
 
+# Caching
 
-Though simple, hopefully the above examples convey some of the flexibility of 
-the configuration options available in `styler`. Let us for now focus on a 
-configuration with `strict = TRUE` and `scope = "tokens"` and illustrate a few 
-more examples of code before and after styling.
+styler is rather slow, so leveraging a cache for styled code brings big speedups
+in many situations. Starting with version `1.3.0`, you can benefit from it. For
+people using styler interactively (e.g. in RStudio), typing
+`styler::cache_info()` and then confirming the creation of a permanent cache is
+sufficient. Please refer to `help("caching")` for more information. The cache is
+by default dependent on the version of styler which means if you upgrade, the
+cache will be re-built. Also, the cache takes literally 0 disk space because
+only the hash of styled code is stored.
+
+# Dry mode
+
+As of version `1.3.2`, styler has a dry mode which avoids writing output to the
+file(s) you want to format. The following options are available:
+
+- *off* (default): Write back to the file if applying styling changes the
+  input.
+
+- *on*: Applies styling and returns the results without writing changes (if any) back to the file(s).
+
+- *fail*: returns an error if the result of styling is not identical to the
+  input.
+
+In any case, you can use the (invisible) return value of `style_file()` and
+friends to learn how files were changed (or would have changed):
+
+```{r}
+out <- withr::with_tempfile(
+  "code.R",
+  {
+    writeLines("1+1", "code.R")
+    style_file("code.R", dry = "on")
+  }
+)
+out
+```
+
+# More configuration options
+
+### Roxygen code example styling
+
+This is enabled by default, you can turn it off with `include_roxygen_examples = FALSE`.
+
+### Custom math token spacing
 
 `styler` can identify and handle unary operators and other math tokens:
 
@@ -121,74 +203,23 @@ more examples of code before and after styling.
 1++1-1-1/2
 ```
 
-This is tidyverse style. However, styler offers very granular control for 
-math token spacing. Assuming you like spacing around `+` and `-`, but not 
-around `/` and `*` and `^`, do the following:
+This is tidyverse style. However, styler offers very granular control for math
+token spacing. Assuming you like spacing around `+` and `-`, but not around `/`
+and `*` and `^`, do the following:
+
 ```{r}
 style_text(
-  "1++1/2*2^2", 
+  "1++1/2*2^2",
   math_token_spacing = specify_math_token_spacing(zero = c("'/'", "'*'", "'^'"))
 )
 ```
 
-It can also format complicated expressions that involve line breaking and 
-indention based on both brace expressions and operators:
+### Custom indention
 
-```{styler}
-if (x >3) {stop("this is an error")} else {
-c(there_are_fairly_long,
-1 / 33 * 
-2 * long_long_variable_names)%>% k(
+If you, say, don't want comments starting with `###` to be indented and
+indention to be 4 instead of two spaces, you can formulate an unindention rule
+and set `indent_by` to 4:
 
-) }
-```
-
-Lines are broken after `(` if a function call spans multiple lines:
-
-```{styler}
-do_a_long_and_complicated_fun_cal("which", has, way, to, 
-                              "and longer then lorem ipsum in its full length"
-                              )
-```
-
-`styler` replaces `=` with `<-` for assignment:
-```{styler}
-one = "one string"
-```
-
-It converts single quotes within strings if necessary:
-```{styler}
-one <- 'one string'
-two <- "one string in a 'string'"
-```
-
-And adds braces to function calls in pipes:
-
-```{styler}
-a %>%
-  b %>%
-  c
-```
-
-Function declarations are indented if multi-line:
-
-```{styler}
-my_fun <- function(x, 
-y, 
-z) {
-  just(z)
-}
-```
-
-`styler` can also deal with tidyeval syntax:
-
-```{styler}
-mtcars %>%
-  group_by( !!my_vars )
-```
-
-If you, say, don't want comments starting with `###` to be indented, you can 
-formulate an unindention rule:
 ```{r}
 style_text(
   c(
@@ -198,8 +229,14 @@ style_text(
     "33",
     "}"
   ),
-  reindention = specify_reindention(regex_pattern = "###", indention = 0)
-  
+  reindention = specify_reindention(regex_pattern = "###", indention = 0),
+  indent_by = 4
 )
 ```
 
+### Custom style guides
+
+These verse some (not all) configurations exposed in `style_file()` and friends
+as well as `tidyverse_style()`. If the above did not give you the flexibility
+you hoped for, your can create your own style guide and customize styler even
+further, as described in `vignette("customizing_styler")`.

--- a/vignettes/strict.Rmd
+++ b/vignettes/strict.Rmd
@@ -23,7 +23,10 @@ knitr::knit_engines$set(list(
         before <- options$code
         after <- as.character(styler::style_text(options$code, strict = FALSE))
         if (!identical(trimws(before, "right"), after)) {
-          stop("Before unlike after:", before)
+          stop(
+            "Before unlike after. Before:", paste(before, sep = "\n"),
+            "After: ", paste(after, sep = "\n")
+          )
         }
         after
       },

--- a/vignettes/strict.Rmd
+++ b/vignettes/strict.Rmd
@@ -1,0 +1,95 @@
+---
+title: "The effect of `strict = FALSE`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{The effect of `strict = FALSE`}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  results = "hide"
+)
+
+knitr::knit_engines$set(list(
+  styler = function(options) {
+    options$comment <- ""
+    knitr::engine_output(
+      options,
+      {
+        before <- options$code
+        after <- as.character(styler::style_text(options$code, strict = FALSE))
+        if (!identical(trimws(before, "right"), after)) {
+          stop("Before unlike after:", before)
+        }
+        after
+      },
+      ""
+    )
+  }
+))
+```
+
+This vignette shows how output from styler might differ when `strict = FALSE`. 
+For brevity, we don't show the output of `strict = TRUE`, but it should be 
+pretty simple for the user to derive it form the bullet or simply paste the 
+code in the console to see the output.
+
+```{r setup}
+library(styler)
+```
+
+* multi-line function declarations without curly braces are tolerated.
+
+```{styler}
+function()
+  NULL
+```
+
+* Spaces before opening parenthesis, tilde as well as around comments and math token must 
+  be at least one, not exactly one.
+
+```{styler}
+1  +    (1 + 3)
+1 ~  more()   #   comment
+```
+* More than one line break is tolerated before closing curly brace and line 
+  breaks between curly and round braces are not removed. 
+```{styler}
+test({
+  1
+  
+}
+)
+
+```
+
+* Multi-line calls don't  put the closing brace on a new line nor trigger a line
+  break after the opening brace.
+
+```{styler}
+call(
+  this)
+call(2,
+  more
+)
+
+```
+
+* No line break inserted after pipes nor ggplot2 or pipe expressions.
+
+```{styler}
+ggplot2::ggplot(data, aes(x, y)) + geom_line() + scale_x_continuous()
+
+this %>% is() %>% a() %>% long() %>% pipe()
+```
+
+* ifelse statements don't get curly braces added when multi-line.
+
+```{styler}
+if (TRUE) 3  else 
+  5
+```

--- a/vignettes/strict.Rmd
+++ b/vignettes/strict.Rmd
@@ -78,7 +78,6 @@ call(
 call(2,
   more
 )
-
 ```
 
 * No line break inserted after pipes nor ggplot2 or pipe expressions.

--- a/vignettes/strict.Rmd
+++ b/vignettes/strict.Rmd
@@ -35,7 +35,7 @@ knitr::knit_engines$set(list(
 
 This vignette shows how output from styler might differ when `strict = FALSE`. 
 For brevity, we don't show the output of `strict = TRUE`, but it should be 
-pretty simple for the user to derive it form the bullet or simply paste the 
+pretty simple for the user to derive it from the bullet point(s) or simply paste the 
 code in the console to see the output.
 
 ```{r setup}

--- a/vignettes/strict.Rmd
+++ b/vignettes/strict.Rmd
@@ -61,10 +61,9 @@ function()
 ```{styler}
 test({
   1
-  
+
 }
 )
-
 ```
 
 * Multi-line calls don't  put the closing brace on a new line nor trigger a line

--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -1,10 +1,10 @@
 ---
-title: "An introduction to styler"
+title: "Get started"
 author: "Lorenz Walthert"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{An introduction to styler}
+  %\VignetteIndexEntry{Get started}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Get started"
-author: "Lorenz Walthert"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Get started}
@@ -43,7 +41,7 @@ Beyond that, styler can be used through other tools documented in the
 
 styler separates the abstract definition of a style guide from the application
 of it. That's why you must supply a style guide via `transformers` when
-styling:
+styling (in case you don't want to rely on the defaults):
 
 ```{r}
 library(styler)

--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -194,7 +194,7 @@ out
 
 ### Roxygen code example styling
 
-This is enabled by default, you can turn it of with `include_roxygen_examples`.
+This is enabled by default, you can turn it off with `include_roxygen_examples = FALSE`.
 
 ### Custom math token spacing
 

--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -1,0 +1,243 @@
+---
+title: "An introduction to styler"
+author: "Lorenz Walthert"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{An introduction to styler}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, echo = FALSE}
+knitr::opts_chunk$set(echo = TRUE, comment = "")
+knitr::knit_engines$set(list(
+  styler = function(options) {
+    options$comment <- ""
+    knitr::engine_output(
+      options,
+      c("# Before", options$code),
+      c("# After", styler::style_text(options$code))
+    )
+  }
+))
+```
+
+# Entry-points
+
+styler provides the following API to format code:
+
+* `style_file()` styles .R, .Rmd .Rnw and .Rprofile files.
+
+* `style_dir()` styles all .R and/or .Rmd files in a directory.
+
+* `style_pkg()` styles the source files of an R package.
+
+* RStudio Addins for styling the active file, styling the current package and
+  styling the highlighted selection, see `help("styler_addins")`.
+
+Beyond that, styler can be used through other tools documented in the
+`vignette("adoption")`.
+
+### Passing arguments to the style guide
+
+styler separates the abstract definition of a style guide from the application
+of it. That's why you must supply a style guide via `transformers` when
+styling:
+
+```{r}
+library(styler)
+style_text("a + b", transformers = tidyverse_style(scope = "indention"))
+```
+
+The styler API was designed so that you can pass arguments to the style guide
+via the styling function (e.g. `style_file()`) to allow more concise syntax:
+
+```{r, results = 'hide'}
+# equivalent
+style_text("a + b", transformers = tidyverse_style(scope = "indention"))
+style_text("a + b", scope = "indention")
+```
+
+The magic is possible thanks to `...`. See `style_text()` for details.
+
+# Invasiveness 
+
+### `scope`: What to style? 
+
+This argument of `tidyverse_style()` determines the invasiveness of styling. The
+following levels for `scope` are available (in increasing order):
+
+* "none": Performs no transformation at all.
+
+* "spaces": Manipulates spacing between token on the same line.
+
+* "indention": Manipulates the indention, i.e. number of spaces at the beginning
+  of each line.
+
+* "line_breaks": Manipulates line breaks between tokens.
+
+* "tokens": manipulates tokens.
+
+There are two ways to specify the scope of styling.
+
+* As a string: In this case all less invasive scope levels are implied, e.g.
+  `"line_breaks"` includes `"indention"`, `"spaces"`. This is brief and what
+  most users need. This is supported in `styler >= 1.0.0`.
+
+* As vector of class `AsIs`: Each level has to be listed explicitly by wrapping
+  one ore more levels of the scope in `I()`. This offers more granular control
+  at the expense of more verbosity. This is supported in `styler > 1.3.2`.
+
+```{r}
+# tokens and everything less invasive
+style_text("a=2", scope = "tokens")
+
+# just tokens and indention
+style_text("a=2", scope = I(c("tokens", "indention")))
+```
+
+As you can see from the output, the assignment operator `=` is replaced with
+`<-` in both cases, but spacing remained unchanged in the second example.
+
+### How `strict` do you want styler to be?
+
+Another option that is helpful to determine the level of 'invasiveness' is
+`strict` (defaulting to `TRUE`). Some rules won't be applied so strictly with
+`strict = FALSE`, assuming you deliberately formatted things the way they are.
+Please see in `vignette("strict")`. For `styler >= 1.2` alignment in function
+calls is detected and preserved even with `strict = TRUE`,
+
+e.g.
+
+```{r}
+style_text(
+  "tibble::tibble(
+     small  = 2 ,
+     medium = 4,#comment without space
+     large  = 6
+   )"
+)
+```
+
+The details are in `vignette("detect-alignment")`.
+
+# Ignoring certain lines
+
+You can tell styler to ignore some lines if you want to keep current formatting.
+You can mark whole blocks or inline expressions with `styler: on` and `styler:
+off`:
+
+```{r}
+styler::style_text(
+  "
+  #> blocks
+  blibala= 3
+  # styler: off
+  I_have(good+reasons, to = turn_off,
+    styler
+  )
+  # styler: on
+  1+1
+
+  #> inline
+  ignore( this) # styler: off
+  f( ) # not ignored anymore
+"
+)
+```
+You can also use custom markers as described in 
+`help("stylerignore", package = "styler")`. As described above and in
+`vignette("detect-alignment")`,
+some alignment is recognized and hence, *stylerignore* should not 
+be necessary in that context.
+
+# Caching
+
+styler is rather slow, so leveraging a cache for styled code brings big speedups
+in many situations. Starting with version `1.3.0`, you can benefit from it. For
+people using styler interactively (e.g. in RStudio), typing
+`styler::cache_info()` and then confirming the creation of a permanent cache is
+sufficient. Please refer to `help("caching")` for more information. The cache is
+by default dependent on the version of styler which means if you upgrade, the
+cache will be re-built. Also, the cache takes literally 0 disk space because
+only the hash of styled code is stored.
+
+# Dry mode
+
+As of version `1.3.2`, styler has a dry mode which avoids writing output to the
+file(s) you want to format. The following options are available:
+
+- *off* (default): Write back to the file if applying styling changes the
+  input.
+
+- *on*: Like *off*, but not writing back.
+
+- *fail*: returns an error if the result of styling is not identical to the
+  input.
+
+In any case, you can use the (invisible) return value of `style_file()` and
+friends to learn how files were changed (or would have changed):
+
+```{r}
+out <- withr::with_tempfile(
+  "code.R",
+  {
+    writeLines("1+1", "code.R")
+    style_file("code.R", dry = "on")
+  }
+)
+out
+```
+
+# More configuration options
+
+### Roxygen code example styling
+
+This is enabled by default, you can turn it of with `include_roxygen_examples`.
+
+### Custom math token spacing
+
+`styler` can identify and handle unary operators and other math tokens:
+
+```{styler}
+1++1-1-1/2
+```
+
+This is tidyverse style. However, styler offers very granular control for math
+token spacing. Assuming you like spacing around `+` and `-`, but not around `/`
+and `*` and `^`, do the following:
+
+```{r}
+style_text(
+  "1++1/2*2^2",
+  math_token_spacing = specify_math_token_spacing(zero = c("'/'", "'*'", "'^'"))
+)
+```
+
+### Custom indention
+
+If you, say, don't want comments starting with `###` to be indented and
+indention to be 4 instead of two spaces, you can formulate an unindention rule
+and set `indent_by` to 4:
+
+```{r}
+style_text(
+  c(
+    "a <- function() {",
+    "### not to be indented",
+    "# indent normally",
+    "33",
+    "}"
+  ),
+  reindention = specify_reindention(regex_pattern = "###", indention = 0),
+  indent_by = 4
+)
+```
+
+### Custom style guides
+
+These verse some (not all) configurations exposed in `style_file()` and friends
+as well as `tidyverse_style()`. If the above did not give you the flexibility
+you hoped for, your can create your own style guide and customize styler even
+further, as described in `vignette("customizing_styler")`.

--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -35,7 +35,7 @@ styler provides the following API to format code:
   styling the highlighted selection, see `help("styler_addins")`.
 
 Beyond that, styler can be used through other tools documented in the
-`vignette("adoption")`.
+`vignette("third-party-integration")`.
 
 ### Passing arguments to the style guide
 

--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -104,10 +104,7 @@ Another option that is helpful to determine the level of 'invasiveness' is
 `strict` (defaulting to `TRUE`). Some rules won't be applied so strictly with
 `strict = FALSE`, assuming you deliberately formatted things the way they are.
 Please see in `vignette("strict")`. For `styler >= 1.2` alignment in function
-calls is detected and preserved even with `strict = TRUE`,
-
-e.g.
-
+calls is detected and preserved so you don't need `strict = FALSE`, e.g.
 ```{r}
 style_text(
   "tibble::tibble(

--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -171,7 +171,7 @@ file(s) you want to format. The following options are available:
 - *off* (default): Write back to the file if applying styling changes the
   input.
 
-- *on*: Like *off*, but not writing back.
+- *on*: Applies styling and returns the results without writing changes (if any) back to the file(s).
 
 - *fail*: returns an error if the result of styling is not identical to the
   input.

--- a/vignettes/third-party-integration.Rmd
+++ b/vignettes/third-party-integration.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Adoption of styler"
+title: "Third-party integration of styler"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Adoption of styler}
+  %\VignetteIndexEntry{Third-party integration of styler}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
This PR improves documentation in various ways, in particular: 

* README: 
  * moves adoption and examples out to vignettes. 
  * move feature overview to intro vignette.
  * drop contributing guidelines.
  * updates badges (gh actions, travis appveyor etc).
  * add motivation
* big review of intro to styler vignette and rebranding as 'Get started' article with direct link in navbar, in particular:
  * caching
  * stylerignore
  * dry mode
  * scope specification
  * alignment detection
* caching and alignment: better cross-linking and documentation.
* add vignette with examples for `strict = FALSE`.
* add jupyter lab integration to adaption vignette.