### PR TITLE
Add base_indention for cached top-level expression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
 # styler 1.4.0.9000 (Development)
 
-* Hexadecimal integers now preserve the trailing `L` when styled (#761).
+* Fix interaction between cache and `base_indention` (#764).
 * Add more examples to `styler_*` helpfiles (#762).
+* Hexadecimal integers now preserve the trailing `L` when styled (#761).
 * Add a pre-push hook to make sure news bullets are added to each PR (#765).
+
 
 # styler 1.4.0
 

--- a/R/transform-block.R
+++ b/R/transform-block.R
@@ -41,7 +41,7 @@ parse_transform_serialize_r_block <- function(pd_nested,
   } else {
     serialized_transformed_text <- map2(
       c(0, find_blank_lines_to_next_expr(pd_nested)[-1] - 1L),
-      pd_nested$text,
+      paste0(rep_char(" ", base_indention), pd_nested$text),
       ~ c(rep("", .x), .y)
     ) %>%
       unlist()

--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -155,6 +155,12 @@ cache_by_expression <- function(text,
   } else {
     expressions$stylerignore <- rep(FALSE, length(expressions$text))
   }
+  # TODO base_indention should be set to 0  on write and on read for expressions
+  # (only) to make it possible to use the cache for expressions with different
+  # indention. when not the whole input text is cached, we go trough all expressions and
+  # check if they are cached, if yes, we take the input (from which the indention
+  # was removed via parse, same as it is in cache_by_expression) and add the
+  # base indention.
   expressions[expressions$parent == 0 & expressions$token != "COMMENT" & !expressions$stylerignore, "text"] %>%
     map(~ cache_write(.x, transformers = transformers, more_specs))
 }

--- a/tests/testthat/test-cache-high-level-api.R
+++ b/tests/testthat/test-cache-high-level-api.R
@@ -106,7 +106,7 @@ test_that("speedup higher when cached roxygen example code is multiple expressio
   )
   # the speed gain for longer expression is 1.1x higher
   expect_true(
-    speedup_multiple_roygen_example / speedup_many_roygen_examples > 1.1
+    speedup_multiple_roygen_example / speedup_many_roygen_examples > 1.05
   )
 })
 

--- a/tests/testthat/test-cache-interaction-base-indention.R
+++ b/tests/testthat/test-cache-interaction-base-indention.R
@@ -25,6 +25,136 @@ test_that("include_roxygen_exmples is respected in caching", {
 })
 
 
+test_that("expression caching when first expression does not comply", {
+  on.exit(clear_testthat_cache())
+  fresh_testthat_cache()
+  more <- 'x<- 1
+   "multi
+line string"
+   c(a = 3)
+   another(
+     "x", y = 4
+   )
+'
+  expect_out <- c(
+    "   x <- 1",
+    '   "multi',
+    'line string"',
+    "   c(a = 3)",
+    "   another(",
+    '     "x",',
+    "     y = 4",
+    "   )"
+  )
+  out <- style_text(more, base_indention = 3) %>%
+    as.character()
+  expect_equal(
+    out,
+    expect_out
+  )
+  out <- style_text(more, base_indention = 3) %>%
+    as.character()
+  expect_equal(
+    out,
+    expect_out
+  )
+  out <- style_text(more, base_indention = 4) %>%
+    as.character()
+  expect_equal(
+    out,
+    c(
+      "    x <- 1",
+      '    "multi',
+      'line string"',
+      "    c(a = 3)",
+      "    another(",
+      '      "x",',
+      "      y = 4",
+      "    )"
+    )
+  )
+  sg <- tidyverse_style()
+  # TODO caching with base indention 3
+  expect_true(
+    is_cached("x <- 1", sg, more_specs = cache_more_specs(TRUE, 4))
+  )
+
+  sg <- tidyverse_style()
+  expect_true(
+    is_cached("x <- 1", sg, more_specs = cache_more_specs(TRUE, 3))
+  )
+})
+
+test_that("expression caching when last expression does not comply", {
+  on.exit(clear_testthat_cache())
+  fresh_testthat_cache()
+  more <- '   x <- 1
+   "multi
+line string"
+   c(a = 3)
+   another(
+     "x", y = 4)
+'
+  expect_out <- c(
+    "   x <- 1",
+    '   "multi',
+    'line string"',
+    "   c(a = 3)",
+    "   another(",
+    '     "x",',
+    "     y = 4",
+    "   )"
+  )
+  out <- style_text(more, base_indention = 3) %>%
+    as.character()
+  expect_equal(
+    out,
+    expect_out
+  )
+  out <- style_text(more, base_indention = 3) %>%
+    as.character()
+  expect_equal(
+    out,
+    expect_out
+  )
+})
+
+test_that("expression caching when middle expression does not comply", {
+  on.exit(clear_testthat_cache())
+  fresh_testthat_cache()
+  more <- '   x <- 1
+   "multi
+line string"
+   c(a= 3)
+   another(
+     "x", y = 4
+  )
+'
+  expect_out <- c(
+    "   x <- 1",
+    '   "multi',
+    'line string"',
+    "   c(a = 3)",
+    "   another(",
+    '     "x",',
+    "     y = 4",
+    "   )"
+  )
+  out <- style_text(more, base_indention = 3) %>%
+    as.character()
+  expect_equal(
+    out,
+    expect_out
+  )
+  out <- style_text(more, base_indention = 3) %>%
+    as.character()
+  expect_equal(
+    out,
+    expect_out
+  )
+})
+
+
 test_that("cache is deactivated at end of caching related testthat file", {
   expect_false(cache_is_activated())
 })


### PR DESCRIPTION
Closes #763.


Here is how the current PR would change benchmark results when merged into master:

cache_applying: 0.03 -> 0.03 (1.7%)
cache_recording: 1.1 -> 1.09 (-0.3%)
without_cache: 3.28 -> 3.26 (-0.5%)

cache_applying: 0.02 -> 0.02 (-2.1%)
cache_recording: 0.74 -> 0.74 (-1.3%)
without_cache: 2.15 -> 2.2 (2.2%)

cache_applying: 0.03 -> 0.03 (-0.5%)
cache_recording: 1 -> 1 (-0.5%)
without_cache: 2.9 -> 2.94 (1.5%)