### PR TITLE
Enforce news update on push

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,5 @@ revdep
 ^touchstone$
 ^\.github$
 ^LICENSE\.md$
+^inst/hooks/$
+^inst/WORDLIST$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,4 @@ repos:
         entry: inst/hooks/require-news-update.R
         stages: [push]
         language: script
+        files: ""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
         language: fail
         files: '\.Rhistory|\.RData|\.Rds|\.rds$'
         # `exclude: <regex>` to allow committing specific files.
+    -   id: require-news-on-push
+        name: Require bullet in NEWS.md
+        description: NEWS.md must be updated with every PR.
+        entry: inst/hooks/require-news-update.R
+        stages: [push]
+        language: script

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 # All available hooks: https://pre-commit.com/hooks.html
 # R specific hooks: https://github.com/lorenzwalthert/precommit
+default_stages: [commit]
+
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
     rev: v0.1.2.9001

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # styler 1.4.0.9000 (Development)
 
 * Hexadecimal integers now preserve the trailing `L` when styled (#761).
-
 * Add more examples to `styler_*` helpfiles (#762).
+* Add a pre-push hook to make sure news bullets are added to each PR (#765).
+
 # styler 1.4.0
 
 ## API Changes

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -73,6 +73,7 @@ github
 gitsum
 GSOC
 hashFiles
+helpfiles
 href
 http
 https

--- a/inst/hooks/require-news-update.R
+++ b/inst/hooks/require-news-update.R
@@ -1,5 +1,10 @@
 #! /usr/local/bin/Rscript
-args <- commandArgs(trailingOnly = TRUE)
+args <- system2(
+  "git",
+  c("diff", "upstream/master", "--name-only"),
+  stdout = TRUE
+)
+
 if (!any(args == "NEWS.md")) {
   rlang::abort("Must have a news entry before pushing.")
 }

--- a/inst/hooks/require-news-update.R
+++ b/inst/hooks/require-news-update.R
@@ -1,0 +1,5 @@
+#! /usr/local/bin/Rscript
+args <- commandArgs(trailingOnly = TRUE)
+if (!any(args == "NEWS.md")) {
+  rlang::abort("Must have a news entry before pushing.")
+}


### PR DESCRIPTION
We always forget to add a news bullet. Then continuous benchmark runs long and we might even eventually forget to add one. This hook prevents this.