### PR TITLE
styler.quiet should be respected in cache utils

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_stages: [commit]
 
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 0cdf06628ef4ea54b20ed2feede10dad1fd9f304
+    rev: a632da39a23e806f06261ebf0cf294e1b70428f2
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]

--- a/API
+++ b/API
@@ -2,9 +2,9 @@
 
 ## Exported functions
 
-cache_activate(cache_name = NULL, verbose = TRUE)
+cache_activate(cache_name = NULL, verbose = !getOption("styler.quiet", FALSE))
 cache_clear(cache_name = NULL, ask = TRUE)
-cache_deactivate(verbose = TRUE)
+cache_deactivate(verbose = !getOption("styler.quiet", FALSE))
 cache_info(cache_name = NULL, format = "both")
 create_style_guide(initialize = default_style_guide_attributes, line_break = NULL, space = NULL, token = NULL, indention = NULL, use_raw_indention = FALSE, reindention = tidyverse_reindention(), style_guide_name = NULL, style_guide_version = NULL, more_specs_style_guide = NULL, transformers_drop = specify_transformers_drop())
 default_style_guide_attributes(pd_flat)

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,8 @@
 * `#>` is recognized as an output marker and no space is added after `#` (#771).
 * R code chunks in nested non-R chunks in R markdown don't yield an error 
   anymore when document is styled, chunks are still not styled (#788, #794).
+* `cache_activate()` and `cache_deactivate()` now respect the R 
+  option `styler.quiet` (#797).
 * `multi_line` attribute in parse table is now integer, not boolean (#782).
 * style guide used in Addin is verified when set via R option (#789).
 * improve pkgdown author URLs (#775).

--- a/R/ui-caching.R
+++ b/R/ui-caching.R
@@ -130,7 +130,7 @@ cache_info <- function(cache_name = NULL, format = "both") {
 #'   function is doing.
 #' @family cache managers
 #' @export
-cache_activate <- function(cache_name = NULL, verbose = TRUE) {
+cache_activate <- function(cache_name = NULL, verbose = !getOption("styler.quiet", FALSE)) {
   if (!is.null(cache_name)) {
     options("styler.cache_name" = cache_name)
   } else {
@@ -149,7 +149,7 @@ cache_activate <- function(cache_name = NULL, verbose = TRUE) {
 
 #' @rdname cache_activate
 #' @export
-cache_deactivate <- function(verbose = TRUE) {
+cache_deactivate <- function(verbose = !getOption("styler.quiet", FALSE)) {
   options("styler.cache_name" = NULL)
 
   if (verbose) {

--- a/man/cache_activate.Rd
+++ b/man/cache_activate.Rd
@@ -5,9 +5,9 @@
 \alias{cache_deactivate}
 \title{Activate or deactivate the styler cache}
 \usage{
-cache_activate(cache_name = NULL, verbose = TRUE)
+cache_activate(cache_name = NULL, verbose = !getOption("styler.quiet", FALSE))
 
-cache_deactivate(verbose = TRUE)
+cache_deactivate(verbose = !getOption("styler.quiet", FALSE))
 }
 \arguments{
 \item{cache_name}{The name of the styler cache to use. If

--- a/touchstone/script.R
+++ b/touchstone/script.R
@@ -5,7 +5,7 @@ refs_install()
 benchmark_run_ref(
   expr_before_benchmark = c("library(styler)", "cache_deactivate()"),
   without_cache = 'style_pkg("touchstone/sources/here", filetype = c("R", "rmd"))',
-  n = 30
+  n = 3
 )
 
 styler::cache_clear()
@@ -13,7 +13,7 @@ styler::cache_clear()
 benchmark_run_ref(
   expr_before_benchmark = c("library(styler)", "cache_activate()"),
   cache_applying = 'style_pkg("touchstone/sources/here", filetype = c("R", "rmd"))',
-  n = 30
+  n = 3
 )
 
 styler::cache_clear()

--- a/touchstone/script.R
+++ b/touchstone/script.R
@@ -5,7 +5,7 @@ refs_install()
 benchmark_run_ref(
   expr_before_benchmark = c("library(styler)", "cache_deactivate()"),
   without_cache = 'style_pkg("touchstone/sources/here", filetype = c("R", "rmd"))',
-  n = 3
+  n = 30
 )
 
 styler::cache_clear()
@@ -13,7 +13,7 @@ styler::cache_clear()
 benchmark_run_ref(
   expr_before_benchmark = c("library(styler)", "cache_activate()"),
   cache_applying = 'style_pkg("touchstone/sources/here", filetype = c("R", "rmd"))',
-  n = 3
+  n = 30
 )
 
 styler::cache_clear()
@@ -27,7 +27,7 @@ benchmark_run_ref(
     "gert::git_reset_hard(repo = 'touchstone/sources/here')",
     'style_pkg("touchstone/sources/here", filetype = c("R", "rmd"))'
   ),
-  n = 10
+  n = 30
 )
 
 styler::cache_clear()

--- a/touchstone/script.R
+++ b/touchstone/script.R
@@ -5,7 +5,7 @@ refs_install()
 benchmark_run_ref(
   expr_before_benchmark = c("library(styler)", "cache_deactivate()"),
   without_cache = 'style_pkg("touchstone/sources/here", filetype = c("R", "rmd"))',
-  n = 10
+  n = 30
 )
 
 styler::cache_clear()
@@ -13,7 +13,7 @@ styler::cache_clear()
 benchmark_run_ref(
   expr_before_benchmark = c("library(styler)", "cache_activate()"),
   cache_applying = 'style_pkg("touchstone/sources/here", filetype = c("R", "rmd"))',
-  n = 10
+  n = 30
 )
 
 styler::cache_clear()


### PR DESCRIPTION
Closes #796. 


* cache_applying (issue-796 -> master): 
0.12 (± 0.01) -> 0.12 (± 0.01): (0%)
* cache_recording (issue-796 -> master): 1.64 (± 0.03) -> 1.64 (± 0.04): (0%)
* without_cache (issue-796 -> master): 4.16 (± 0.05) -> 4.16 (± 0.05): (0%)

New version:

Here is how the current PR would change benchmark results when merged into master:

* cache_applying (merge issue-796 into master): 0.12 -> 0.12 [-0.96%, +7.66%]
* cache_recording (merge issue-796 into master): 1.61 -> 1.62 [-0.01%, +1.6%]
* without_cache (merge issue-796 into master): 4.23 -> 4.25 [-0.3%, +1.21%]