### PR TITLE
Release styler 1.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: styler
 Title: Non-Invasive Pretty Printing of R Code
-Version: 1.4.1.9003
+Version: 1.5.0
 Authors@R: 
     c(person(given = "Kirill",
              family = "Müller",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: styler
 Title: Non-Invasive Pretty Printing of R Code
-Version: 1.5.0
+Version: 1.5.1
 Authors@R: 
     c(person(given = "Kirill",
              family = "Müller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# styler 1.4.1.9000 (Development version)
+# styler 1.5.0
 
 ## Alignment detection
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# styler 1.5.0
+# styler 1.5.1
 
 ## Alignment detection
 

--- a/R/set-assert-args.R
+++ b/R/set-assert-args.R
@@ -21,7 +21,7 @@ set_arg_write_tree <- function(write_tree) {
 #' @inheritParams make_transformer
 #' @keywords internal
 assert_transformers <- function(transformers) {
-  version_cutoff <- 1.5
+  version_cutoff <- 2.0
   no_name <- is.null(transformers$style_guide_name)
   no_version <- is.null(transformers$style_guide_version)
   if (no_name || no_version) {

--- a/R/transform-code.R
+++ b/R/transform-code.R
@@ -90,7 +90,7 @@ identify_raw_chunks <- function(lines, filetype, engine_pattern = get_engine_pat
     starts <- grep("^[\t >]*```+\\s*\\{([Rr]( *[ ,].*)?)\\}\\s*$", lines, perl = TRUE)
     ends <- grep("^[\t >]*```+\\s*$", lines, perl = TRUE)
     ends <- purrr::imap_int(starts, ~ ends[which(ends > .x)[1]]) %>%
-      na.omit()
+      stats::na.omit()
     if (length(starts) != length(ends) || anyDuplicated(ends) != 0) {
       abort("Malformed file!")
     }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,8 @@
-This is a follow-up release to version 1.4.0 (2021-03-22) because a major bug
-(https://github.com/r-lib/styler/issues/763) had to be resolved. The last 
-update of styler was more than a year ago. 
 
 ## Test environments
 
 * local OS X install (10.15.7): R 4.0.3
-* ubuntu 16.04 (on GitHub Actions): R devel, R 4.0.3, R 3.6, R 3.5, R 3.4, R 3.3
+* ubuntu 18.04 (on GitHub Actions): R devel, R 4.0.3, R 3.6, R 3.5, R 3.4, R 3.3
 * Windows Server 10 (on GitHub Actions): R 3.6, R 4.0.3
 * win-builder: R devel
 
@@ -35,11 +32,14 @@ I also ran R CMD check on all downstream dependencies of styler using the
 revdepcheck package. The 
 downstream dependencies are: 
 
-* Reverse imports:	biocthis, exampletestr, languageserver, questionr,
-  shinyobjects, ShinyQuickStarter, systemPipeShiny.
-* Reverse suggests:	autothresholdr, crunch, datastructures, drake, epigraphdb,
-  knitr, netReg, nph, precommit, reprex, shinydashboardPlus, shinyMonacoEditor,
-  usethis
+* Reverse imports: biocthis, exampletestr, iNZightTools, languageserver, 
+  questionr, shinymeta, shinyobjects, ShinyQuickStarter, systemPipeShiny, 
+  tidypaleo.
+  	
+* Reverse suggests:	autothresholdr, crunch, datastructures, drake, epigraphdb, 
+  knitr, multiverse, nph, precommit, reprex, shinydashboardPlus, 
+  shinyMonacoEditor, usethis.
+
 
 All of them finished R CMD CHECK with the same number of ERRORS, WARNINGS and 
 NOTES as with the current CRAN version of styler, which means the new 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -86,6 +86,7 @@ innode
 integrations
 interaces
 invasiveness
+iNZightTools
 io
 ixmypi
 ized
@@ -193,6 +194,7 @@ setCacheRootPath
 setdiff
 setenv
 shinydashboardPlus
+shinymeta
 shinyMonacoEditor
 shinyobjects
 ShinyQuickStarter
@@ -217,6 +219,7 @@ testthat
 tibble
 tibbles
 tidyeval
+tidypaleo
 tidyr
 tidyverse
 Tidyverse

--- a/tests/testthat/test-exception_handling.R
+++ b/tests/testthat/test-exception_handling.R
@@ -25,7 +25,7 @@ test_that("style_file with no tokens returns empty string and warning", {
 
 test_that("warning is given when transformers does not contain a version", {
   sg <- create_style_guide(style_guide_version = NULL)
-  if (packageVersion("styler") < "1.5") {
+  if (packageVersion("styler") < "2.0") {
     expect_fun <- expect_warning
   } else {
     expect_fun <- expect_error


### PR DESCRIPTION
We have a new CRAN release coming up 🥳 See [`NEWS.md`](https://styler.r-lib.org/dev/news/index.html) for new features.

Prepare for release:

* [x] `devtools::check_win_devel()`
* [x] [Polish NEWS](http://style.tidyverse.org/news.html#before-release)
* [ ] If new failures, update `email.yml` then `revdepcheck::revdep_email_maintainers()`

Perform release:

* [x] Create RC branch (for bigger releases)
* [x] Bump version (in DESCRIPTION and NEWS)
* [ ] `devtools::submit_cran()`
* [ ] `pkgdown::build_site()`
* [ ] Approve email

Wait for CRAN...

* [ ] Tag release
* [ ] Merge RC back to master branch
* [ ] Bump dev version
* [ ] update CRAN speed change monitor PR.