### PR TITLE
Allow comments in roxygen comment blocks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: styler
 Title: Non-Invasive Pretty Printing of R Code
-Version: 1.5.1.9000
+Version: 1.5.1.9001
 Authors@R: 
     c(person(given = "Kirill",
              family = "Müller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,14 @@
+
 # styler 1.5.1.9000 (Development version)
+
+* Files with `.Rmarkdown` extension are now recognized as an R markdown files in `style_file()` and friends (#824).
 
 * Don't break line before comments in pipes (#822).
 
-* Files with `.Rmarkdown` extension are now recognised as an R markdown files in `style_file()` and friends (#824)
+* Ordinary comments (starting with `#`) within a roxygen code example block 
+  (starting with `#'`) are now recognized and preserved (#830).
+
+* Break the line between `%>%` and `{` inside and outside function calls (#825).
 
 # styler 1.5.1
 

--- a/R/roxygen-examples-add-remove.R
+++ b/R/roxygen-examples-add-remove.R
@@ -34,14 +34,28 @@ remove_roxygen_header <- function(text) {
 
 #' Add the roxygen mask to code
 #'
+#' This function compares `text` with `initial_text` to make sure a mask is only
+#' added to roxygen comments, not ordinary comments
 #' @param text Character vector with code.
 #' @param example_type Either 'examples' or 'examplesIf'.
 #' @keywords internal
 #' @importFrom purrr map2_chr
-add_roxygen_mask <- function(text, example_type) {
+add_roxygen_mask <- function(text, initial_text, example_type) {
   space <- ifelse(text == "", "", " ")
-  c(
+  out <- c(
     paste0("#' @", example_type, space[1], text[1]),
     map2_chr(space[-1], text[-1], ~ paste0("#'", .x, .y))
   )
+
+  ordinary_comment <- grep("^#[^']", initial_text, value = TRUE)
+  if (length(ordinary_comment) == 0L) {
+    return(out)
+  }
+  without_mask <- remove_roxygen_mask(out)
+  for (idx in seq_along(ordinary_comment)) {
+    to_replace <- which(ordinary_comment[idx] == without_mask)[1]
+    out[to_replace] <- ordinary_comment[idx]
+    without_mask[to_replace] <- NA
+  }
+  out
 }

--- a/R/roxygen-examples-add-remove.R
+++ b/R/roxygen-examples-add-remove.R
@@ -37,6 +37,8 @@ remove_roxygen_header <- function(text) {
 #' This function compares `text` with `initial_text` to make sure a mask is only
 #' added to roxygen comments, not ordinary comments
 #' @param text Character vector with code.
+#' @param initial_text The roxygen code example to style with mask and
+#'   potentially ordinary comments.
 #' @param example_type Either 'examples' or 'examplesIf'.
 #' @keywords internal
 #' @importFrom purrr map2_chr

--- a/R/roxygen-examples-parse.R
+++ b/R/roxygen-examples-parse.R
@@ -131,6 +131,8 @@ emulate_rd <- function(roxygen) {
       gsub("^#'(\\s|\t)*@examples(If)?(\\s|\t)*(.*)", "#' @examples \\4", roxygen),
       "x <- 1"
     )
+    roxygen <- gsub("(^#)[^']", "#' #", roxygen)
+
     text <- roxygen2::roc_proc_text(
       roxygen2::rd_roclet(),
       paste(roxygen, collapse = "\n")

--- a/R/roxygen-examples.R
+++ b/R/roxygen-examples.R
@@ -25,24 +25,12 @@ style_roxygen_code_example <- function(example, transformers, base_indention) {
 style_roxygen_code_example_one <- function(example_one, transformers, base_indention) {
   bare <- parse_roxygen(example_one)
   one_dont <- split(bare$text, factor(cumsum(bare$text %in% dont_keywords())))
-  styled <- map(one_dont, style_roxygen_code_example_segment,
+  map(one_dont, style_roxygen_code_example_segment,
     transformers = transformers,
     base_indention = base_indention
   ) %>%
     flatten_chr() %>%
-    add_roxygen_mask(bare$example_type)
-
-  ordinary_comment <- grep("^#[^']", example_one, value = TRUE)
-  if (length(ordinary_comment) == 0L) {
-    return(styled)
-  }
-  without_mask <- remove_roxygen_mask(styled)
-  for (idx in seq_along(ordinary_comment)) {
-    to_replace <- which(ordinary_comment[idx] == without_mask)[1]
-    styled[to_replace] <- ordinary_comment[idx]
-    without_mask[to_replace] <- NA
-  }
-  styled
+    add_roxygen_mask(example_one, bare$example_type)
 }
 
 #' Style a roxygen code example segment

--- a/R/roxygen-examples.R
+++ b/R/roxygen-examples.R
@@ -25,12 +25,23 @@ style_roxygen_code_example <- function(example, transformers, base_indention) {
 style_roxygen_code_example_one <- function(example_one, transformers, base_indention) {
   bare <- parse_roxygen(example_one)
   one_dont <- split(bare$text, factor(cumsum(bare$text %in% dont_keywords())))
-  map(one_dont, style_roxygen_code_example_segment,
+  styled <- map(one_dont, style_roxygen_code_example_segment,
     transformers = transformers,
     base_indention = base_indention
   ) %>%
     flatten_chr() %>%
     add_roxygen_mask(bare$example_type)
+
+  ordinary_comment <- grep("^#[^']", example_one, value = TRUE)
+  if (length(ordinary_comment) == 0L) {
+    return(styled)
+  }
+  without_mask <- remove_roxygen_mask(styled)
+  for (idx in seq_along(ordinary_comment)) {
+    to_replace <- which(ordinary_comment[idx] == without_mask)[1]
+    styled[to_replace] <- ordinary_comment[idx]
+  }
+  styled
 }
 
 #' Style a roxygen code example segment

--- a/R/roxygen-examples.R
+++ b/R/roxygen-examples.R
@@ -40,6 +40,7 @@ style_roxygen_code_example_one <- function(example_one, transformers, base_inden
   for (idx in seq_along(ordinary_comment)) {
     to_replace <- which(ordinary_comment[idx] == without_mask)[1]
     styled[to_replace] <- ordinary_comment[idx]
+    without_mask[to_replace] <- NA
   }
   styled
 }

--- a/man/add_roxygen_mask.Rd
+++ b/man/add_roxygen_mask.Rd
@@ -4,7 +4,7 @@
 \alias{add_roxygen_mask}
 \title{Add the roxygen mask to code}
 \usage{
-add_roxygen_mask(text, example_type)
+add_roxygen_mask(text, initial_text, example_type)
 }
 \arguments{
 \item{text}{Character vector with code.}
@@ -12,6 +12,7 @@ add_roxygen_mask(text, example_type)
 \item{example_type}{Either 'examples' or 'examplesIf'.}
 }
 \description{
-Add the roxygen mask to code
+This function compares \code{text} with \code{initial_text} to make sure a mask is only
+added to roxygen comments, not ordinary comments
 }
 \keyword{internal}

--- a/man/add_roxygen_mask.Rd
+++ b/man/add_roxygen_mask.Rd
@@ -9,6 +9,9 @@ add_roxygen_mask(text, initial_text, example_type)
 \arguments{
 \item{text}{Character vector with code.}
 
+\item{initial_text}{The roxygen code example to style with mask and
+potentially ordinary comments.}
+
 \item{example_type}{Either 'examples' or 'examplesIf'.}
 }
 \description{

--- a/man/style_pkg.Rd
+++ b/man/style_pkg.Rd
@@ -59,7 +59,7 @@ styling are not identical.}
 }
 \description{
 Performs various substitutions in all \code{.R} files in a package
-(code and tests). One can also (optionally) style \code{.Rmd} \code{.Rmarkdown} and/or
+(code and tests). One can also (optionally) style \code{.Rmd}, \code{.Rmarkdown} and/or
 \code{.Rnw} files (vignettes and readme) by changing the \code{filetype} argument.
 Carefully examine the results after running this function!
 }

--- a/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-in.R
+++ b/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-in.R
@@ -1,0 +1,110 @@
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+#' 1 + 1
+NULL
+
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examplesIf
+#' 1 + 1
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+#' 1 + 1
+# comment
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' 1 + 1
+# comment
+# more
+NULL
+
+#' Example
+#' Random comment
+#' Roxygen
+#' @examples
+# There
+#' 1 + 1
+# comment
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' \dontrun{
+#' 1 + 1
+#' }
+# comment
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' \dontrun{
+#' 1 + 1
+#' } # comment
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# 'There
+#' \dontrun{
+#' 1 + 1
+#' }
+# comment
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' \dontrun{
+# comment
+#' 1 + 1
+#' }
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' \dontrun{
+#' call(
+# comment
+#' 1 + 1
+#' )
+#' }
+# more
+NULL
+
+# nolint start
+#' @examplesIf TRUE
+# nolint end
+#' df %>% func()
+func <- function() NULL

--- a/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-in.R
+++ b/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-in.R
@@ -108,3 +108,26 @@ NULL
 # nolint end
 #' df %>% func()
 func <- function() NULL
+
+
+#' Hi
+# Comment
+#' @examples
+#' 1 + 1
+# this
+# this
+#this
+# thi3
+#' c()
+NULL
+
+#' Hi
+# Comment
+#' @examples
+#' 1 + 1
+# this
+# this 
+#this
+# thi3
+#' c()
+NULL

--- a/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-in_tree
+++ b/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-in_tree
@@ -107,13 +107,35 @@ ROOT (token: short_text [lag_newlines/spaces] {pos_id})
  ¦--COMMENT: #' @e [1/0] {106}                         
  ¦--COMMENT: # nol [1/0] {107}                         
  ¦--COMMENT: #' df [1/0] {108}                         
- °--expr: func  [1/0] {109}                            
-     ¦--expr: func [0/1] {111}                         
-     ¦   °--SYMBOL: func [0/0] {110}                   
-     ¦--LEFT_ASSIGN: <- [0/1] {112}                    
-     °--expr: funct [0/0] {113}                        
-         ¦--FUNCTION: funct [0/0] {114}                
-         ¦--'(': ( [0/0] {115}                         
-         ¦--')': ) [0/1] {116}                         
-         °--expr: NULL [0/0] {118}                     
-             °--NULL_CONST: NULL [0/0] {117}           
+ ¦--expr: func  [1/0] {109}                            
+ ¦   ¦--expr: func [0/1] {111}                         
+ ¦   ¦   °--SYMBOL: func [0/0] {110}                   
+ ¦   ¦--LEFT_ASSIGN: <- [0/1] {112}                    
+ ¦   °--expr: funct [0/0] {113}                        
+ ¦       ¦--FUNCTION: funct [0/0] {114}                
+ ¦       ¦--'(': ( [0/0] {115}                         
+ ¦       ¦--')': ) [0/1] {116}                         
+ ¦       °--expr: NULL [0/0] {118}                     
+ ¦           °--NULL_CONST: NULL [0/0] {117}           
+ ¦--COMMENT: #' Hi [3/0] {119}                         
+ ¦--COMMENT: # Com [1/0] {120}                         
+ ¦--COMMENT: #' @e [1/0] {121}                         
+ ¦--COMMENT: #' 1  [1/0] {122}                         
+ ¦--COMMENT: # thi [1/0] {123}                         
+ ¦--COMMENT: # thi [1/0] {124}                         
+ ¦--COMMENT: #this [1/0] {125}                         
+ ¦--COMMENT: # thi [1/0] {126}                         
+ ¦--COMMENT: #' c( [1/0] {127}                         
+ ¦--expr: NULL [1/0] {129}                             
+ ¦   °--NULL_CONST: NULL [0/0] {128}                   
+ ¦--COMMENT: #' Hi [2/0] {130}                         
+ ¦--COMMENT: # Com [1/0] {131}                         
+ ¦--COMMENT: #' @e [1/0] {132}                         
+ ¦--COMMENT: #' 1  [1/0] {133}                         
+ ¦--COMMENT: # thi [1/0] {134}                         
+ ¦--COMMENT: # thi [1/0] {135}                         
+ ¦--COMMENT: #this [1/0] {136}                         
+ ¦--COMMENT: # thi [1/0] {137}                         
+ ¦--COMMENT: #' c( [1/0] {138}                         
+ °--expr: NULL [1/0] {140}                             
+     °--NULL_CONST: NULL [0/0] {139}                   

--- a/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-in_tree
+++ b/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-in_tree
@@ -1,0 +1,119 @@
+ROOT (token: short_text [lag_newlines/spaces] {pos_id})
+ ¦--COMMENT: #' Ex [0/0] {1}                           
+ ¦--COMMENT: # Ran [1/0] {2}                           
+ ¦--COMMENT: #' Ro [1/0] {3}                           
+ ¦--COMMENT: #' @e [1/0] {4}                           
+ ¦--COMMENT: #' 1  [1/0] {5}                           
+ ¦--expr: NULL [1/0] {7}                               
+ ¦   °--NULL_CONST: NULL [0/0] {6}                     
+ ¦--COMMENT: #' Ex [3/0] {8}                           
+ ¦--COMMENT: # Ran [1/0] {9}                           
+ ¦--COMMENT: #' Ro [1/0] {10}                          
+ ¦--COMMENT: #' @e [1/0] {11}                          
+ ¦--COMMENT: #' 1  [1/0] {12}                          
+ ¦--expr: NULL [1/0] {14}                              
+ ¦   °--NULL_CONST: NULL [0/0] {13}                    
+ ¦--COMMENT: #' Ex [2/0] {15}                          
+ ¦--COMMENT: # Ran [1/0] {16}                          
+ ¦--COMMENT: #' Ro [1/0] {17}                          
+ ¦--COMMENT: #' @e [1/0] {18}                          
+ ¦--COMMENT: #' 1  [1/0] {19}                          
+ ¦--COMMENT: # com [1/0] {20}                          
+ ¦--COMMENT: # mor [1/0] {21}                          
+ ¦--expr: NULL [1/0] {23}                              
+ ¦   °--NULL_CONST: NULL [0/0] {22}                    
+ ¦--COMMENT: #' Ex [2/0] {24}                          
+ ¦--COMMENT: # Ran [1/0] {25}                          
+ ¦--COMMENT: #' Ro [1/0] {26}                          
+ ¦--COMMENT: #' @e [1/0] {27}                          
+ ¦--COMMENT: # The [1/0] {28}                          
+ ¦--COMMENT: #' 1  [1/0] {29}                          
+ ¦--COMMENT: # com [1/0] {30}                          
+ ¦--COMMENT: # mor [1/0] {31}                          
+ ¦--expr: NULL [1/0] {33}                              
+ ¦   °--NULL_CONST: NULL [0/0] {32}                    
+ ¦--COMMENT: #' Ex [2/0] {34}                          
+ ¦--COMMENT: #' Ra [1/0] {35}                          
+ ¦--COMMENT: #' Ro [1/0] {36}                          
+ ¦--COMMENT: #' @e [1/0] {37}                          
+ ¦--COMMENT: # The [1/0] {38}                          
+ ¦--COMMENT: #' 1  [1/0] {39}                          
+ ¦--COMMENT: # com [1/0] {40}                          
+ ¦--COMMENT: # mor [1/0] {41}                          
+ ¦--expr: NULL [1/0] {43}                              
+ ¦   °--NULL_CONST: NULL [0/0] {42}                    
+ ¦--COMMENT: #' Ex [2/0] {44}                          
+ ¦--COMMENT: # Ran [1/0] {45}                          
+ ¦--COMMENT: #' Ro [1/0] {46}                          
+ ¦--COMMENT: #' @e [1/0] {47}                          
+ ¦--COMMENT: # The [1/0] {48}                          
+ ¦--COMMENT: #' \d [1/0] {49}                         
+ ¦--COMMENT: #' 1  [1/0] {50}                          
+ ¦--COMMENT: #' } [1/0] {51}                           
+ ¦--COMMENT: # com [1/0] {52}                          
+ ¦--COMMENT: # mor [1/0] {53}                          
+ ¦--expr: NULL [1/0] {55}                              
+ ¦   °--NULL_CONST: NULL [0/0] {54}                    
+ ¦--COMMENT: #' Ex [2/0] {56}                          
+ ¦--COMMENT: # Ran [1/0] {57}                          
+ ¦--COMMENT: #' Ro [1/0] {58}                          
+ ¦--COMMENT: #' @e [1/0] {59}                          
+ ¦--COMMENT: # The [1/0] {60}                          
+ ¦--COMMENT: #' \d [1/0] {61}                         
+ ¦--COMMENT: #' 1  [1/0] {62}                          
+ ¦--COMMENT: #' }  [1/0] {63}                          
+ ¦--COMMENT: # mor [1/0] {64}                          
+ ¦--expr: NULL [1/0] {66}                              
+ ¦   °--NULL_CONST: NULL [0/0] {65}                    
+ ¦--COMMENT: #' Ex [2/0] {67}                          
+ ¦--COMMENT: # Ran [1/0] {68}                          
+ ¦--COMMENT: #' Ro [1/0] {69}                          
+ ¦--COMMENT: #' @e [1/0] {70}                          
+ ¦--COMMENT: # 'Th [1/0] {71}                          
+ ¦--COMMENT: #' \d [1/0] {72}                         
+ ¦--COMMENT: #' 1  [1/0] {73}                          
+ ¦--COMMENT: #' } [1/0] {74}                           
+ ¦--COMMENT: # com [1/0] {75}                          
+ ¦--COMMENT: # mor [1/0] {76}                          
+ ¦--expr: NULL [1/0] {78}                              
+ ¦   °--NULL_CONST: NULL [0/0] {77}                    
+ ¦--COMMENT: #' Ex [2/0] {79}                          
+ ¦--COMMENT: # Ran [1/0] {80}                          
+ ¦--COMMENT: #' Ro [1/0] {81}                          
+ ¦--COMMENT: #' @e [1/0] {82}                          
+ ¦--COMMENT: # The [1/0] {83}                          
+ ¦--COMMENT: #' \d [1/0] {84}                         
+ ¦--COMMENT: # com [1/0] {85}                          
+ ¦--COMMENT: #' 1  [1/0] {86}                          
+ ¦--COMMENT: #' } [1/0] {87}                           
+ ¦--COMMENT: # mor [1/0] {88}                          
+ ¦--expr: NULL [1/0] {90}                              
+ ¦   °--NULL_CONST: NULL [0/0] {89}                    
+ ¦--COMMENT: #' Ex [2/0] {91}                          
+ ¦--COMMENT: # Ran [1/0] {92}                          
+ ¦--COMMENT: #' Ro [1/0] {93}                          
+ ¦--COMMENT: #' @e [1/0] {94}                          
+ ¦--COMMENT: # The [1/0] {95}                          
+ ¦--COMMENT: #' \d [1/0] {96}                         
+ ¦--COMMENT: #' ca [1/0] {97}                          
+ ¦--COMMENT: # com [1/0] {98}                          
+ ¦--COMMENT: #' 1  [1/0] {99}                          
+ ¦--COMMENT: #' ) [1/0] {100}                          
+ ¦--COMMENT: #' } [1/0] {101}                          
+ ¦--COMMENT: # mor [1/0] {102}                         
+ ¦--expr: NULL [1/0] {104}                             
+ ¦   °--NULL_CONST: NULL [0/0] {103}                   
+ ¦--COMMENT: # nol [2/0] {105}                         
+ ¦--COMMENT: #' @e [1/0] {106}                         
+ ¦--COMMENT: # nol [1/0] {107}                         
+ ¦--COMMENT: #' df [1/0] {108}                         
+ °--expr: func  [1/0] {109}                            
+     ¦--expr: func [0/1] {111}                         
+     ¦   °--SYMBOL: func [0/0] {110}                   
+     ¦--LEFT_ASSIGN: <- [0/1] {112}                    
+     °--expr: funct [0/0] {113}                        
+         ¦--FUNCTION: funct [0/0] {114}                
+         ¦--'(': ( [0/0] {115}                         
+         ¦--')': ) [0/1] {116}                         
+         °--expr: NULL [0/0] {118}                     
+             °--NULL_CONST: NULL [0/0] {117}           

--- a/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-out.R
+++ b/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-out.R
@@ -109,3 +109,26 @@ NULL
 # nolint end
 #' df %>% func()
 func <- function() NULL
+
+
+#' Hi
+# Comment
+#' @examples
+#' 1 + 1
+# this
+# this
+# this
+# thi3
+#' c()
+NULL
+
+#' Hi
+# Comment
+#' @examples
+#' 1 + 1
+# this
+# this
+# this
+# thi3
+#' c()
+NULL

--- a/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-out.R
+++ b/tests/testthat/roxygen-examples-complete/25-ordinary-comment-in-example-out.R
@@ -1,0 +1,111 @@
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+#' 1 + 1
+NULL
+
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examplesIf
+#' 1 + 1
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+#' 1 + 1
+# comment
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' 1 + 1
+# comment
+# more
+NULL
+
+#' Example
+#' Random comment
+#' Roxygen
+#' @examples
+# There
+#' 1 + 1
+# comment
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' \dontrun{
+#' 1 + 1
+#' }
+# comment
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' \dontrun{
+#' 1 + 1
+#' # comment
+#' }
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# 'There
+#' \dontrun{
+#' 1 + 1
+#' }
+# comment
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' \dontrun{
+# comment
+#' 1 + 1
+#' }
+# more
+NULL
+
+#' Example
+# Random comment
+#' Roxygen
+#' @examples
+# There
+#' \dontrun{
+#' call(
+#'   # comment
+#'   1 + 1
+#' )
+#' }
+# more
+NULL
+
+# nolint start
+#' @examplesIf TRUE
+# nolint end
+#' df %>% func()
+func <- function() NULL

--- a/tests/testthat/test-roxygen-examples-complete.R
+++ b/tests/testthat/test-roxygen-examples-complete.R
@@ -126,4 +126,9 @@ test_that("analogous to test-roxygen-examples-complete", {
     "roxygen-examples-complete", "^24",
     transformer = style_text
   ), NA)
+
+  expect_warning(test_collection(
+    "roxygen-examples-complete", "^25",
+    transformer = style_text
+  ), NA)
 })


### PR DESCRIPTION
Closes #828, but more generally adds support for random comments in roxygen code blocks. Cases were internally distinct in `emulate_rd()` depending on the presence of special characters like `%`, which is why only a `%>%` triggered a problem.