### PR TITLE
Two error on unsupported {roxygen2} `@examplesIf` condition

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,12 @@
 
 * Don't break line before comments in pipes (#822).
 
-* Ordinary comments (starting with `#`) within a roxygen code example block 
+* Ordinary comments (starting with `#`) that break a roxygen code example block 
   (starting with `#'`) are now recognized and preserved (#830).
 
+* `@examplesIf` conditions longer than one line after styling throw an error for
+  compatibility with {roxygen2} (#833).
+  
 * R Markdown chunk headers are no longer required to be parsable R code (#832).
 
 * Break the line between `%>%` and `{` inside and outside function calls (#825).

--- a/R/roxygen-examples.R
+++ b/R/roxygen-examples.R
@@ -25,11 +25,24 @@ style_roxygen_code_example <- function(example, transformers, base_indention) {
 style_roxygen_code_example_one <- function(example_one, transformers, base_indention) {
   bare <- parse_roxygen(example_one)
   one_dont <- split(bare$text, factor(cumsum(bare$text %in% dont_keywords())))
-  map(one_dont, style_roxygen_code_example_segment,
+  unmasked <- map(one_dont, style_roxygen_code_example_segment,
     transformers = transformers,
     base_indention = base_indention
   ) %>%
-    flatten_chr() %>%
+    flatten_chr()
+  if (bare$example_type == "examplesIf") {
+    with_handlers(
+      parse_text(unmasked[1]),
+      error = function(e) {
+        abort(paste0(
+          "Could not style condition in `@examplesIf` because it would result ",
+          "in multi-line condition, which is currently not supported in ",
+          "{roxygen2} (see https://github.com/r-lib/roxygen2/issues/1242)."
+        ))
+      }
+    )
+  }
+  unmasked %>%
     add_roxygen_mask(example_one, bare$example_type)
 }
 

--- a/tests/testthat/test-roxygen-examples-complete.R
+++ b/tests/testthat/test-roxygen-examples-complete.R
@@ -117,10 +117,10 @@ test_that("analogous to test-roxygen-examples-complete", {
     transformer = style_text
   ), NA)
 
-  expect_warning(test_collection(
+  expect_error(test_collection(
     "roxygen-examples-complete", "^23",
     transformer = style_text
-  ), NA)
+  ), "issues/1242")
 
   expect_warning(test_collection(
     "roxygen-examples-complete", "^24",


### PR DESCRIPTION
Closes #826.