### PR TITLE
Also recognize lintr ignore markers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ VignetteBuilder:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate",
     "pkgapi::api_roclet"))
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.2
 Collate: 
     'addins.R'
     'communicate.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # styler 1.6.2.9000 (Development version)
 
 
+* multiple stylerignore patterns can be specified at once and lintr markers 
+  `# nolint`, `# nolint start` and `# nolint end` are now by default recognized
+  in addition to `# styler: off` and `# styler: on` (#849).
+
 # styler 1.6.2
 
 * clean up cache files older than one week (#842).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,21 @@
 # styler 1.6.2.9000 (Development version)
 
 
-* multiple stylerignore patterns can be specified at once and lintr markers 
-  `# nolint`, `# nolint start` and `# nolint end` are now by default recognized
-  in addition to `# styler: off` and `# styler: on` (#849).
+* stylerignore markers are now interpreted as regular expressions instead of 
+  comments that must match exactly. This allows to specify multiple markers in 
+  one regular expression for `styler.ignore_start` and `styler.ignore_stop`, 
+  e.g. to use markers for lintr and styler on the same line, you can use
+  `options(styler.ignore_start = "nolint start|styler: off"`:
+
+  ```r
+  # nolint start, styler: off
+  1 +1
+  # nolint end
+  # styler: on
+  ```
+  As a consequence of this approach, the defaults for `styler.ignore_start` and 
+  `styler.ignore_stop` omit the `#` (#849).
+
 
 # styler 1.6.2
 

--- a/R/nest.R
+++ b/R/nest.R
@@ -162,23 +162,17 @@ find_pos_id_to_keep <- function(pd) {
 #' Styling is on for all lines by default when you run styler.
 #'
 #' - To mark the start of a sequence where you want to turn styling off, use
-#'   `# styler: off`. For styler version > 1.6.2, `# nolint` and `#nolint start`
-#'   also works by default.
+#'   `# styler: off`.
 #' - To mark the end of this sequence, put `# styler: on` in your code. After
-#'   that line, styler will again format your code. For styler version > 1.6.2,
-#'   `#nolint end` also works by default.
+#'   that line, styler will again format your code.
 #' - To ignore an inline statement (i.e. just one line), place `# styler: off`
-#'   at the end of the line. Note that inline statements cannot contain other
-#'   comments apart from the marker, i.e. a line like
-#'   `1 # comment # styler: off` won't be ignored. For styler version > 1.6.2,
-#'   `# nolint` and `#nolint start` also works.
-#'
+#'   at the end of the line.
 #' To use something else as start and stop markers, set the R options
 #' `styler.ignore_start` and
 #' `styler.ignore_stop` using [options()]. For styler version > 1.6.2, the
-#' option supports character vectors longer than one. If you want these
-#' settings to persist over multiple R sessions, consider setting them in your
-#' R profile, e.g. with `usethis::edit_rprofile()`.
+#' option supports character vectors longer than one and the marker are not
+#' exactly matched, but using a  regular expression, which means you can have
+#' multiple marker on one line, e.g. `# nolint start styler: off`.
 #' @name stylerignore
 #' @examples
 #' # as long as the order of the markers is correct, the lines are ignored.

--- a/R/nest.R
+++ b/R/nest.R
@@ -159,20 +159,24 @@ find_pos_id_to_keep <- function(pd) {
 #' [detected by styler](https://styler.r-lib.org/articles/detect-alignment.html),
 #' making stylerignore redundant. See a few illustrative examples below.
 #' @details
-#' Styling is on by default when you run styler.
+#' Styling is on for all lines by default when you run styler.
 #'
 #' - To mark the start of a sequence where you want to turn styling off, use
-#'   `# styler: off`.
+#'   `# styler: off`. For styler version > 1.6.2, `# nolint` and `#nolint start`
+#'   also works by default.
 #' - To mark the end of this sequence, put `# styler: on` in your code. After
-#'   that line, styler will again format your code.
+#'   that line, styler will again format your code. For styler version > 1.6.2,
+#'   `#nolint end` also works by default.
 #' - To ignore an inline statement (i.e. just one line), place `# styler: off`
 #'   at the end of the line. Note that inline statements cannot contain other
 #'   comments apart from the marker, i.e. a line like
-#'   `1 # comment # styler: off` won't be ignored.
+#'   `1 # comment # styler: off` won't be ignored. For styler version > 1.6.2,
+#'   `# nolint` and `#nolint start` also works.
 #'
 #' To use something else as start and stop markers, set the R options
 #' `styler.ignore_start` and
-#' `styler.ignore_stop` using [options()]. If you want these
+#' `styler.ignore_stop` using [options()]. For styler version > 1.6.2, the
+#' option supports character vectors longer than one. If you want these
 #' settings to persist over multiple R sessions, consider setting them in your
 #' R profile, e.g. with `usethis::edit_rprofile()`.
 #' @name stylerignore

--- a/R/stylerignore.R
+++ b/R/stylerignore.R
@@ -48,13 +48,13 @@ env_add_stylerignore <- function(pd_flat) {
 #'
 #' See examples in [stylerignore]. Note that you should reuse the stylerignore
 #' column to compute switch points or similar and not a plain
-#' `pd$text == option_read("styler.ignore_start")` because that will fail to
+#' `pd$text %in% option_read("styler.ignore_start")` because that will fail to
 #' give correct switch points in the case stylerignore sequences are invalid.
 #' @param pd_flat A parse table.
 #' @keywords internal
 add_stylerignore <- function(pd_flat) {
   parse_text <- trimws(pd_flat$text)
-  start_candidate <- parse_text == option_read("styler.ignore_start")
+  start_candidate <- parse_text %in% option_read("styler.ignore_start")
   pd_flat$stylerignore <- rep(FALSE, length(start_candidate))
   env_current$any_stylerignore <- any(start_candidate)
   if (!env_current$any_stylerignore) {
@@ -64,7 +64,7 @@ add_stylerignore <- function(pd_flat) {
   pd_flat_lat_line1 <- lag(pd_flat$line2, default = 0)
   on_same_line <- pd_flat$line1 == pd_flat_lat_line1
   cumsum_start <- cumsum(start_candidate & !on_same_line)
-  cumsum_stop <- cumsum(parse_text == option_read("styler.ignore_stop"))
+  cumsum_stop <- cumsum(parse_text %in% option_read("styler.ignore_stop"))
   pd_flat$indicator_off <- cumsum_start + cumsum_stop
   is_invalid <- cumsum_start - cumsum_stop < 0 | cumsum_start - cumsum_stop > 1
   if (any(is_invalid)) {
@@ -105,7 +105,7 @@ apply_stylerignore <- function(flattened_pd) {
   colnames_required_apply_stylerignore <- c(
     "pos_id_", "lag_newlines", "lag_spaces", "text", "first_pos_id_in_segment"
   )
-  # cannot rely on flattened_pd$text == option_read("styler.ignore_start")
+  # cannot rely on flattened_pd$text %in% option_read("styler.ignore_start")
   # because if the marker logic is not correct (twice off in a row), we'll
   # get it wrong.
   to_ignore <- flattened_pd$stylerignore == TRUE

--- a/R/stylerignore.R
+++ b/R/stylerignore.R
@@ -54,7 +54,9 @@ env_add_stylerignore <- function(pd_flat) {
 #' @keywords internal
 add_stylerignore <- function(pd_flat) {
   parse_text <- trimws(pd_flat$text)
-  start_candidate <- parse_text %in% option_read("styler.ignore_start")
+  start_candidate <- grepl(
+    option_read("styler.ignore_start"), parse_text
+  ) & pd_flat$token == "COMMENT"
   pd_flat$stylerignore <- rep(FALSE, length(start_candidate))
   env_current$any_stylerignore <- any(start_candidate)
   if (!env_current$any_stylerignore) {
@@ -64,7 +66,10 @@ add_stylerignore <- function(pd_flat) {
   pd_flat_lat_line1 <- lag(pd_flat$line2, default = 0)
   on_same_line <- pd_flat$line1 == pd_flat_lat_line1
   cumsum_start <- cumsum(start_candidate & !on_same_line)
-  cumsum_stop <- cumsum(parse_text %in% option_read("styler.ignore_stop"))
+  cumsum_stop <- cumsum(
+    grepl(option_read("styler.ignore_stop"), parse_text) &
+      pd_flat$token == "COMMENT"
+  )
   pd_flat$indicator_off <- cumsum_start + cumsum_stop
   is_invalid <- cumsum_start - cumsum_stop < 0 | cumsum_start - cumsum_stop > 1
   if (any(is_invalid)) {
@@ -105,7 +110,7 @@ apply_stylerignore <- function(flattened_pd) {
   colnames_required_apply_stylerignore <- c(
     "pos_id_", "lag_newlines", "lag_spaces", "text", "first_pos_id_in_segment"
   )
-  # cannot rely on flattened_pd$text %in% option_read("styler.ignore_start")
+  # cannot rely on flattened_pd$text == option_read("styler.ignore_start")
   # because if the marker logic is not correct (twice off in a row), we'll
   # get it wrong.
   to_ignore <- flattened_pd$stylerignore == TRUE

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,8 +5,8 @@
     styler.addins_style_transformer = "styler::tidyverse_style()",
     styler.cache_name = styler_version,
     styler.colored_print.vertical = TRUE,
-    styler.ignore_start = c("# styler: off", "# nolint", "nolint start"),
-    styler.ignore_stop = c("# styler: on", "# nolint end"),
+    styler.ignore_start = "styler: off",
+    styler.ignore_stop = "styler: on",
     styler.quiet = FALSE,
     styler.test_dir_writable = TRUE
   )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,8 +5,8 @@
     styler.addins_style_transformer = "styler::tidyverse_style()",
     styler.cache_name = styler_version,
     styler.colored_print.vertical = TRUE,
-    styler.ignore_start = "# styler: off",
-    styler.ignore_stop = "# styler: on",
+    styler.ignore_start = c("# styler: off", "# nolint", "nolint start"),
+    styler.ignore_stop = c("# styler: on", "# nolint end"),
     styler.quiet = FALSE,
     styler.test_dir_writable = TRUE
   )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -103,6 +103,7 @@ LF
 LIBS
 lifecycle
 Ligges
+lintr
 linux
 lorenz
 lorenzwalthert

--- a/man/add_stylerignore.Rd
+++ b/man/add_stylerignore.Rd
@@ -24,7 +24,7 @@ the R options \code{styler.ignore_start} and \code{styler.ignore_stop}.
 
 See examples in \link{stylerignore}. Note that you should reuse the stylerignore
 column to compute switch points or similar and not a plain
-\code{pd$text == option_read("styler.ignore_start")} because that will fail to
+\code{pd$text \%in\% option_read("styler.ignore_start")} because that will fail to
 give correct switch points in the case stylerignore sequences are invalid.
 }
 \keyword{internal}

--- a/man/stylerignore.Rd
+++ b/man/stylerignore.Rd
@@ -10,21 +10,25 @@ for \verb{styler > 1.2.0}, some alignment is
 making stylerignore redundant. See a few illustrative examples below.
 }
 \details{
-Styling is on by default when you run styler.
+Styling is on for all lines by default when you run styler.
 \itemize{
 \item To mark the start of a sequence where you want to turn styling off, use
-\verb{# styler: off}.
+\verb{# styler: off}. For styler version > 1.6.2, \verb{# nolint} and \verb{#nolint start}
+also works by default.
 \item To mark the end of this sequence, put \verb{# styler: on} in your code. After
-that line, styler will again format your code.
+that line, styler will again format your code. For styler version > 1.6.2,
+\verb{#nolint end} also works by default.
 \item To ignore an inline statement (i.e. just one line), place \verb{# styler: off}
 at the end of the line. Note that inline statements cannot contain other
 comments apart from the marker, i.e. a line like
-\code{1 # comment # styler: off} won't be ignored.
+\code{1 # comment # styler: off} won't be ignored. For styler version > 1.6.2,
+\verb{# nolint} and \verb{#nolint start} also works.
 }
 
 To use something else as start and stop markers, set the R options
 \code{styler.ignore_start} and
-\code{styler.ignore_stop} using \code{\link[=options]{options()}}. If you want these
+\code{styler.ignore_stop} using \code{\link[=options]{options()}}. For styler version > 1.6.2, the
+option supports character vectors longer than one. If you want these
 settings to persist over multiple R sessions, consider setting them in your
 R profile, e.g. with \code{usethis::edit_rprofile()}.
 }

--- a/man/stylerignore.Rd
+++ b/man/stylerignore.Rd
@@ -13,24 +13,18 @@ making stylerignore redundant. See a few illustrative examples below.
 Styling is on for all lines by default when you run styler.
 \itemize{
 \item To mark the start of a sequence where you want to turn styling off, use
-\verb{# styler: off}. For styler version > 1.6.2, \verb{# nolint} and \verb{#nolint start}
-also works by default.
+\verb{# styler: off}.
 \item To mark the end of this sequence, put \verb{# styler: on} in your code. After
-that line, styler will again format your code. For styler version > 1.6.2,
-\verb{#nolint end} also works by default.
+that line, styler will again format your code.
 \item To ignore an inline statement (i.e. just one line), place \verb{# styler: off}
-at the end of the line. Note that inline statements cannot contain other
-comments apart from the marker, i.e. a line like
-\code{1 # comment # styler: off} won't be ignored. For styler version > 1.6.2,
-\verb{# nolint} and \verb{#nolint start} also works.
-}
-
+at the end of the line.
 To use something else as start and stop markers, set the R options
 \code{styler.ignore_start} and
 \code{styler.ignore_stop} using \code{\link[=options]{options()}}. For styler version > 1.6.2, the
-option supports character vectors longer than one. If you want these
-settings to persist over multiple R sessions, consider setting them in your
-R profile, e.g. with \code{usethis::edit_rprofile()}.
+option supports character vectors longer than one and the marker are not
+exactly matched, but using a  regular expression, which means you can have
+multiple marker on one line, e.g. \verb{# nolint start styler: off}.
+}
 }
 \examples{
 # as long as the order of the markers is correct, the lines are ignored.

--- a/tests/testthat/test-stylerignore.R
+++ b/tests/testthat/test-stylerignore.R
@@ -77,49 +77,6 @@ test_that("works with other markers", {
   )
 })
 
-test_that("works with multiple markers", {
-  expect_equal(
-    withr::with_options(
-      list(
-        styler.ignore_start = c("# startignore", "#lintstart"),
-        styler.ignore_stop = "# xxx"
-      ),
-      {
-        style_text(c(
-          "1+1",
-          "#lintstart",
-          "1+1",
-          "# xxx",
-          "1+1"
-        )) %>%
-          as.character()
-      }
-    ),
-    c("1 + 1", "#lintstart", "1+1", "# xxx", "1 + 1")
-  )
-})
-
-test_that("works with multiple markers", {
-  expect_equal(
-    withr::with_options(
-      list(
-        styler.ignore_start = "# startignore",
-        styler.ignore_stop = c("# xxx", "# lintstop")
-      ),
-      {
-        style_text(c(
-          "1+1",
-          "# startignore",
-          "1+1",
-          "# lintstop",
-          "1+1"
-        )) %>%
-          as.character()
-      }
-    ),
-    c("1 + 1", "# startignore", "1+1", "# lintstop", "1 + 1")
-  )
-})
 
 test_that("works for multiple markers inline", {
   withr::local_options(styler.ignore_start = "# noeq", )
@@ -133,6 +90,21 @@ test_that("works for multiple markers inline", {
     c("1 + 1", "1+1# noeq", "1 + 1")
   )
 })
+
+
+test_that("works for multiple markers inline on one line", {
+  withr::local_options(styler.ignore_start = "nolint start|styler: off")
+  expect_equal(
+    style_text(c(
+      "1+1",
+      "1+1# nolint start styler: off",
+      "1+1"
+    )) %>%
+      as.character(),
+    c("1 + 1", "1+1# nolint start styler: off", "1 + 1")
+  )
+})
+
 
 test_that("works with other markers", {
   expect_warning(

--- a/tests/testthat/test-stylerignore.R
+++ b/tests/testthat/test-stylerignore.R
@@ -77,6 +77,63 @@ test_that("works with other markers", {
   )
 })
 
+test_that("works with multiple markers", {
+  expect_equal(
+    withr::with_options(
+      list(
+        styler.ignore_start = c("# startignore", "#lintstart"),
+        styler.ignore_stop = "# xxx"
+      ),
+      {
+        style_text(c(
+          "1+1",
+          "#lintstart",
+          "1+1",
+          "# xxx",
+          "1+1"
+        )) %>%
+          as.character()
+      }
+    ),
+    c("1 + 1", "#lintstart", "1+1", "# xxx", "1 + 1")
+  )
+})
+
+test_that("works with multiple markers", {
+  expect_equal(
+    withr::with_options(
+      list(
+        styler.ignore_start = "# startignore",
+        styler.ignore_stop = c("# xxx", "# lintstop")
+      ),
+      {
+        style_text(c(
+          "1+1",
+          "# startignore",
+          "1+1",
+          "# lintstop",
+          "1+1"
+        )) %>%
+          as.character()
+      }
+    ),
+    c("1 + 1", "# startignore", "1+1", "# lintstop", "1 + 1")
+  )
+})
+
+test_that("works for multiple markers inline", {
+  withr::local_options(styler.ignore_start = "# noeq", )
+  expect_equal(
+    style_text(c(
+      "1+1",
+      "1+1# noeq",
+      "1+1"
+    )) %>%
+      as.character(),
+    c("1 + 1", "1+1# noeq", "1 + 1")
+  )
+})
+
 test_that("works with other markers", {
   expect_warning(
     withr::with_options(


### PR DESCRIPTION
@MichaelChirico what do you think about this? From NEWS.md:

> multiple stylerignore patterns can be specified at once and lintr markers 
  `# nolint`, `# nolint start` and `# nolint end` are now by default recognized
  in addition to `# styler: off` and `# styler: on` (#849).

Closes #848