### PR TITLE
Don't add `()` within substitute piped calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # styler 1.6.2.9000 (Development version)
 
+* Piped function without brackets `substitute(x %>% y)` don't get `()` added
+  anymore, as this can change outcome of the code (#876).
 * Alignment detection respects stylerignore (#850).
 * Add vignette on distributing style guide (#846, #861).
 * Enable pre-commit.ci (#843).

--- a/R/rules-tokens.R
+++ b/R/rules-tokens.R
@@ -17,6 +17,13 @@ resolve_semicolon <- function(pd) {
 }
 
 add_brackets_in_pipe <- function(pd) {
+  if (!identical(pd$text[next_non_comment(pd, 0L)], "substitute")) {
+    pd$child <- map(pd$child, add_brackets_in_pipe_child)
+  }
+  pd
+}
+
+add_brackets_in_pipe_child <- function(pd) {
   is_pipe <- pd$token %in% c("SPECIAL-PIPE", "PIPE")
   Reduce(add_brackets_in_pipe_one, which(is_pipe), init = pd)
 }

--- a/tests/testthat/test-token_adding_removing.R
+++ b/tests/testthat/test-token_adding_removing.R
@@ -43,3 +43,9 @@ test_that("No braces are added if conditional statement is within pipe", {
     transformer = style_text
   ), NA)
 })
+
+test_that("No brace is added within `substitute()`", {
+  expect_warning(test_collection("token_adding_removing", "substitute",
+    transformer = style_text
+  ), NA)
+})

--- a/tests/testthat/token_adding_removing/substitute-in.R
+++ b/tests/testthat/token_adding_removing/substitute-in.R
@@ -1,0 +1,3 @@
+expr <- substitute(airquality %>% FUN_EXPR, env = list(FUN_EXPR = call("FUN_head")))
+a %>%
+  x

--- a/tests/testthat/token_adding_removing/substitute-in_tree
+++ b/tests/testthat/token_adding_removing/substitute-in_tree
@@ -1,0 +1,39 @@
+ROOT (token: short_text [lag_newlines/spaces] {pos_id})      
+ ¦--expr: expr  [0/0] {1}                                    
+ ¦   ¦--expr: expr [0/1] {3}                                 
+ ¦   ¦   °--SYMBOL: expr [0/0] {2}                           
+ ¦   ¦--LEFT_ASSIGN: <- [0/1] {4}                            
+ ¦   °--expr: subst [0/0] {5}                                
+ ¦       ¦--expr: subst [0/0] {7}                            
+ ¦       ¦   °--SYMBOL_FUNCTION_CALL: subst [0/0] {6}        
+ ¦       ¦--'(': ( [0/0] {8}                                 
+ ¦       ¦--expr: airqu [0/0] {9}                            
+ ¦       ¦   ¦--expr: airqu [0/1] {11}                       
+ ¦       ¦   ¦   °--SYMBOL: airqu [0/0] {10}                 
+ ¦       ¦   ¦--SPECIAL-PIPE: %>% [0/1] {12}                 
+ ¦       ¦   °--expr: FUN_E [0/0] {14}                       
+ ¦       ¦       °--SYMBOL: FUN_E [0/0] {13}                 
+ ¦       ¦--',': , [0/1] {15}                                
+ ¦       ¦--SYMBOL_SUB: env [0/1] {16}                       
+ ¦       ¦--EQ_SUB: = [0/1] {17}                             
+ ¦       ¦--expr: list( [0/0] {18}                           
+ ¦       ¦   ¦--expr: list [0/0] {20}                        
+ ¦       ¦   ¦   °--SYMBOL_FUNCTION_CALL: list [0/0] {19}    
+ ¦       ¦   ¦--'(': ( [0/0] {21}                            
+ ¦       ¦   ¦--SYMBOL_SUB: FUN_E [0/1] {22}                 
+ ¦       ¦   ¦--EQ_SUB: = [0/1] {23}                         
+ ¦       ¦   ¦--expr: call( [0/0] {24}                       
+ ¦       ¦   ¦   ¦--expr: call [0/0] {26}                    
+ ¦       ¦   ¦   ¦   °--SYMBOL_FUNCTION_CALL: call [0/0] {25}
+ ¦       ¦   ¦   ¦--'(': ( [0/0] {27}                        
+ ¦       ¦   ¦   ¦--expr: "FUN_ [0/0] {29}                   
+ ¦       ¦   ¦   ¦   °--STR_CONST: "FUN_ [0/0] {28}          
+ ¦       ¦   ¦   °--')': ) [0/0] {30}                        
+ ¦       ¦   °--')': ) [0/0] {31}                            
+ ¦       °--')': ) [0/0] {32}                                
+ °--expr: a %>% [1/0] {33}                                   
+     ¦--expr: a [0/1] {35}                                   
+     ¦   °--SYMBOL: a [0/0] {34}                             
+     ¦--SPECIAL-PIPE: %>% [0/2] {36}                         
+     °--expr: x [1/0] {38}                                   
+         °--SYMBOL: x [0/0] {37}                             

--- a/tests/testthat/token_adding_removing/substitute-out.R
+++ b/tests/testthat/token_adding_removing/substitute-out.R
@@ -1,0 +1,3 @@
+expr <- substitute(airquality %>% FUN_EXPR, env = list(FUN_EXPR = call("FUN_head")))
+a %>%
+  x()


### PR DESCRIPTION
Closes #873.