### PR TITLE
move if up if else is before

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # styler 1.7.0
 
+* if `else` follows directly after `if`, line breaks are removed (#935).
+
 **API changes**
 
 * new R option `styler.cache_root` (defaulting to `"styler"`) that determines 

--- a/R/rules-line-breaks.R
+++ b/R/rules-line-breaks.R
@@ -153,6 +153,8 @@ style_line_break_around_curly <- function(strict, pd) {
       pd$lag_newlines[is_else] <- 0L
       pd$spaces[c(is_else, FALSE)[-1]] <- 1L
     }
+    is_if_after_else <- pd$token == "ELSE" & pd$token_after == "IF"
+    pd$lag_newlines[lag(is_if_after_else)] <- 0L
   }
   pd
 }

--- a/inst/hooks/require-news-update.R
+++ b/inst/hooks/require-news-update.R
@@ -1,7 +1,7 @@
 #! /usr/local/bin/Rscript
 args <- system2(
   "git",
-  c("diff", "upstream/main", "--name-only"),
+  c("diff", "origin/main", "--name-only"),
   stdout = TRUE
 )
 

--- a/tests/testthat/indention_multiple/if_else_curly-in.R
+++ b/tests/testthat/indention_multiple/if_else_curly-in.R
@@ -37,3 +37,18 @@ foo <- function(x) {
     2
   }
 }
+
+
+if (TRUE) {
+  3
+} else
+  if (FALSE) {
+  4
+}
+
+if (TRUE) {
+  3
+} else # comment
+  if (FALSE) {
+    4
+  }

--- a/tests/testthat/indention_multiple/if_else_curly-out.R
+++ b/tests/testthat/indention_multiple/if_else_curly-out.R
@@ -36,3 +36,17 @@ foo <- function(x) {
     2
   }
 }
+
+
+if (TRUE) {
+  3
+} else  if (FALSE) {
+  4
+}
+
+if (TRUE) {
+  3
+} else # comment
+if (FALSE) {
+  4
+}


### PR DESCRIPTION
Closes #934, solved by changing the line break rule `style_line_break_around_curly()`, which is a bit convoluted but the best fitting rule we have. Not adding new transformers for speed reasons.