### PR TITLE
Make all markdown pandoc compliant

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,13 +1,19 @@
+---
+editor_options: 
+  markdown: 
+    wrap: 79
+---
+
 # MIT License
 
 Copyright (c) 2021 styler authors
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,255 +1,304 @@
+---
+editor_options: 
+  markdown: 
+    wrap: 79
+---
+
 # styler 1.7.0.9000 (Development version)
 
 **Features**
 
-* `filetype` `.qmd` is now supported, but not turned on by default (#931).
-* new R option `styler.ignore_alignment` controls if alignment should be 
-  detected (and preserved) or not (#932).
-  
+-   `filetype` `.qmd` is now supported, but not turned on by default (#931).
+-   new R option `styler.ignore_alignment` controls if alignment should be
+    detected (and preserved) or not (#932).
+
 **Bug Fixes**
 
-* the cache is also invalidated on changing the stylerignore markers (#932).
-* If there are only empty lines in a code chunk, they are all removed (#936).
-* `{` is not put on a new line after `=` and in `function() {` for some edge
-  cases (#939).
-* Parsing of {roxygen2} example comments now also works for edge cases when 
-  there is no literal code immediately following after the end of the example
-  section (#940).
+-   the cache is also invalidated on changing the stylerignore markers (#932).
 
+-   If there are only empty lines in a code chunk, they are all removed (#936).
+
+-   `{` is not put on a new line after `=` and in `function() {` for some edge
+    cases (#939).
+
+-   Parsing of {roxygen2} example comments now also works for edge cases when
+    there is no literal code immediately following after the end of the example
+    section (#940).
+
+**Other**
+
+-   All (R)md files are now formatted with default pandoc markdown formatter.
+    This conversion is required when using the visual mode in RStudio (#941).
 
 # styler 1.7.0
 
-* if `else` follows directly after `if`, line breaks are removed (#935).
+-   if `else` follows directly after `if`, line breaks are removed (#935).
 
 **API changes**
 
-* new R option `styler.cache_root` (defaulting to `"styler"`) that determines 
-  the sub-directory under the {R.cache} cache directory that {styler} uses. Non-
-  default caches won't be cleaned up by {styler}. We suggest `"styler-perm"` 
-  (also used by {precommit}).
+-   new R option `styler.cache_root` (defaulting to `"styler"`) that determines
+    the sub-directory under the {R.cache} cache directory that {styler} uses.
+    Non- default caches won't be cleaned up by {styler}. We suggest
+    `"styler-perm"` (also used by {precommit}).
 
-* stylerignore markers are now interpreted as regular expressions instead of 
-  comments that must match exactly. This allows to specify multiple markers in 
-  one regular expression for `styler.ignore_start` and `styler.ignore_stop`, 
-  e.g. to use markers for lintr and styler on the same line, you can use
-  `options(styler.ignore_start = "nolint start|styler: off"`:
+-   stylerignore markers are now interpreted as regular expressions instead of
+    comments that must match exactly. This allows to specify multiple markers
+    in one regular expression for `styler.ignore_start` and
+    `styler.ignore_stop`, e.g. to use markers for lintr and styler on the same
+    line, you can use
+    `options(styler.ignore_start = "nolint start|styler: off"`:
 
-  ```r
-  # nolint start, styler: off
-  1 +1
-  # nolint end
-  # styler: on
-  ```
-  As a consequence of this approach, the defaults for `styler.ignore_start` and 
-  `styler.ignore_stop` omit the `#` (#849).
+    ``` r
+    # nolint start, styler: off
+    1 +1
+    # nolint end
+    # styler: on
+    ```
 
+    As a consequence of this approach, the defaults for `styler.ignore_start`
+    and `styler.ignore_stop` omit the `#` (#849).
 
 **Features**
 
-* {styler} can be ran via GitHub Actions using 
-  `usethis::use_github_action("style")` (#914).
-* added guarantee that styled code is parsable (#892).
-* Developers can now create style guides with indention characters other than 
-  spaces (#916).
+-   {styler} can be ran via GitHub Actions using
+    `usethis::use_github_action("style")` (#914).
+-   added guarantee that styled code is parsable (#892).
+-   Developers can now create style guides with indention characters other than
+    spaces (#916).
 
 **Documentation**
 
-* Add vignette on distributing style guide (#846, #861).
-* Fix argument name `filetype` in Example for `style_dir()` (#855).
-
+-   Add vignette on distributing style guide (#846, #861).
+-   Fix argument name `filetype` in Example for `style_dir()` (#855).
 
 **Bug fixes**
 
-* Piped function without brackets `substitute(x %>% y)` don't get `()` added
-  anymore for one level deep (not more yet, see #889), as this can change 
-  outcome of the code (#876).
-* `.onLoad()` method no longer broken with {cli} >= 3.1 (#893).
-* Function calls containing `+` should no longer give any error on styling when 
-  there are comments and line breaks under certain circumstances (#905). 
-* rules that add tokens don't break stylerignore sequences anymore (#891).
-* Alignment detection respects stylerignore (#850).
-* Unaligned expressions with quoted key (e.g. `c("x" = 2)`) are now correctly
-  detected (#881).
-* `~` causes now indention, like `+`, `-`, `|` etc. (#902).
-* `Warning: Unknown or uninitialised column:` was fixed (#885).
-* function calls with unequal number of token on different lines are no longer 
-  deemed aligned if there are arbitrary spaces around the tokens on the lines 
-  with most tokens (#902).
-* if a line starts with `EQ_SUB` (`=`), the corresponding key is moved to that
-  line too (#923).
-* ensure a trailing blank line also if the input is cached (#867).
-* Preserve trailing blank line in roxygen examples to simplify concatenation of
-  examples (#880).
-* `indenty_by` is now also respected when curly braces are added to an if
-  statement by {styler} (#915).
-* An error is now thrown on styling if input unicode characters can't be 
-  correctly parsed for Windows and R < 4.2 (#883).
-* styling of text does not error anymore when the R option `OutDec` is set to 
-  a non-default value (#912).
-
+-   Piped function without brackets `substitute(x %>% y)` don't get `()` added
+    anymore for one level deep (not more yet, see #889), as this can change
+    outcome of the code (#876).
+-   `.onLoad()` method no longer broken with {cli} \>= 3.1 (#893).
+-   Function calls containing `+` should no longer give any error on styling
+    when there are comments and line breaks under certain circumstances (#905).
+-   rules that add tokens don't break stylerignore sequences anymore (#891).
+-   Alignment detection respects stylerignore (#850).
+-   Unaligned expressions with quoted key (e.g. `c("x" = 2)`) are now correctly
+    detected (#881).
+-   `~` causes now indention, like `+`, `-`, `|` etc. (#902).
+-   `Warning: Unknown or uninitialised column:` was fixed (#885).
+-   function calls with unequal number of token on different lines are no
+    longer deemed aligned if there are arbitrary spaces around the tokens on
+    the lines with most tokens (#902).
+-   if a line starts with `EQ_SUB` (`=`), the corresponding key is moved to
+    that line too (#923).
+-   ensure a trailing blank line also if the input is cached (#867).
+-   Preserve trailing blank line in roxygen examples to simplify concatenation
+    of examples (#880).
+-   `indenty_by` is now also respected when curly braces are added to an if
+    statement by {styler} (#915).
+-   An error is now thrown on styling if input unicode characters can't be
+    correctly parsed for Windows and R \< 4.2 (#883).
+-   styling of text does not error anymore when the R option `OutDec` is set to
+    a non-default value (#912).
 
 **Infrastructure**
 
-* Remove dependency on {xfun} (#866).
-* Remove {glue} dependency that was only used by {touchstone} script and is 
-  declared as a dependency already in the respective action (#910).
-* Bump minimal R requirement to 3.4 in line with the 
-  [tidyverse](https://www.tidyverse.org/blog/2019/04/r-version-support/), which
-  allowed to remove the dependency at {backports} and some exception handling.
-* rename default branch to main (#859).
-* the built package size has been reduced by ~50% by listing `*-in_tree` files
-  in `.Rbuildignore` (#879).
-* Enable pre-commit.ci (#843).
-* use pre-commit via GitHub Actions (#872).
-* terminate running jobs on new push to save resources (#888).
-* Use the {touchstone} GitHub Action instead of the literal script (#889).
-* upgrade R CMD check Github Actions to use `v2`.
-* {styler} test are relaxed to not assume a specific error message on the 
-  wrong usage of `_` (#929).
+-   Remove dependency on {xfun} (#866).
+-   Remove {glue} dependency that was only used by {touchstone} script and is
+    declared as a dependency already in the respective action (#910).
+-   Bump minimal R requirement to 3.4 in line with the
+    [tidyverse](https://www.tidyverse.org/blog/2019/04/r-version-support/),
+    which allowed to remove the dependency at {backports} and some exception
+    handling.
+-   rename default branch to main (#859).
+-   the built package size has been reduced by \~50% by listing `*-in_tree`
+    files in `.Rbuildignore` (#879).
+-   Enable pre-commit.ci (#843).
+-   use pre-commit via GitHub Actions (#872).
+-   terminate running jobs on new push to save resources (#888).
+-   Use the {touchstone} GitHub Action instead of the literal script (#889).
+-   upgrade R CMD check Github Actions to use `v2`.
+-   {styler} test are relaxed to not assume a specific error message on the
+    wrong usage of `_` (#929).
 
 Thanks to all contributors that made this release possible:
 
-[&#x0040;bersbersbers](https://github.com/bersbersbers), [&#x0040;daniel-wrench](https://github.com/daniel-wrench), [&#x0040;dbykova](https://github.com/dbykova), [&#x0040;EngrStudent](https://github.com/EngrStudent), [&#x0040;hadley](https://github.com/hadley), [&#x0040;IndrajeetPatil](https://github.com/IndrajeetPatil), [&#x0040;jam1015](https://github.com/jam1015), [&#x0040;jooyoungseo](https://github.com/jooyoungseo), [&#x0040;kalaschnik](https://github.com/kalaschnik), [&#x0040;kaytif](https://github.com/kaytif), [&#x0040;kpagacz](https://github.com/kpagacz), [&#x0040;krlmlr](https://github.com/krlmlr), [&#x0040;lionel-](https://github.com/lionel-), [&#x0040;lorenzwalthert](https://github.com/lorenzwalthert), [&#x0040;maelle](https://github.com/maelle), [&#x0040;MichaelChirico](https://github.com/MichaelChirico), [&#x0040;mine-cetinkaya-rundel](https://github.com/mine-cetinkaya-rundel), [&#x0040;neuwirthe](https://github.com/neuwirthe), [&#x0040;Polkas](https://github.com/Polkas), [&#x0040;pwang2](https://github.com/pwang2), [&#x0040;sebffischer](https://github.com/sebffischer), [&#x0040;ShixiangWang](https://github.com/ShixiangWang), [&#x0040;ssh352](https://github.com/ssh352), and [&#x0040;xjtusjtu](https://github.com/xjtusjtu).
+[\@bersbersbers](https://github.com/bersbersbers),
+[\@daniel-wrench](https://github.com/daniel-wrench),
+[\@dbykova](https://github.com/dbykova),
+[\@EngrStudent](https://github.com/EngrStudent),
+[\@hadley](https://github.com/hadley),
+[\@IndrajeetPatil](https://github.com/IndrajeetPatil),
+[\@jam1015](https://github.com/jam1015),
+[\@jooyoungseo](https://github.com/jooyoungseo),
+[\@kalaschnik](https://github.com/kalaschnik),
+[\@kaytif](https://github.com/kaytif), [\@kpagacz](https://github.com/kpagacz),
+[\@krlmlr](https://github.com/krlmlr), [\@lionel-](https://github.com/lionel-),
+[\@lorenzwalthert](https://github.com/lorenzwalthert),
+[\@maelle](https://github.com/maelle),
+[\@MichaelChirico](https://github.com/MichaelChirico),
+[\@mine-cetinkaya-rundel](https://github.com/mine-cetinkaya-rundel),
+[\@neuwirthe](https://github.com/neuwirthe),
+[\@Polkas](https://github.com/Polkas), [\@pwang2](https://github.com/pwang2),
+[\@sebffischer](https://github.com/sebffischer),
+[\@ShixiangWang](https://github.com/ShixiangWang),
+[\@ssh352](https://github.com/ssh352), and
+[\@xjtusjtu](https://github.com/xjtusjtu).
 
 # styler 1.6.2
 
-* clean up cache files older than one week (#842).
+-   clean up cache files older than one week (#842).
 
 # styler 1.6.1
 
-* Files with `.Rmarkdown` extension are now recognized as an R markdown files in
-  `style_file()` and friends (#824).
+-   Files with `.Rmarkdown` extension are now recognized as an R markdown files
+    in `style_file()` and friends (#824).
 
-* Don't break line before comments in pipes (#822).
+-   Don't break line before comments in pipes (#822).
 
-* Ordinary comments (starting with `#`) that break a roxygen code example block 
-  (starting with `#'`) are now recognized and preserved (#830).
+-   Ordinary comments (starting with `#`) that break a roxygen code example
+    block (starting with `#'`) are now recognized and preserved (#830).
 
-* `@examplesIf` conditions longer than one line after styling throw an error for
-  compatibility with {roxygen2} (#833).
-  
-* R Markdown chunk headers are no longer required to be parsable R code (#832).
+-   `@examplesIf` conditions longer than one line after styling throw an error
+    for compatibility with {roxygen2} (#833).
 
-* Break the line between `%>%` and `{` inside and outside function calls (#825).
+-   R Markdown chunk headers are no longer required to be parsable R code
+    (#832).
 
-* Add language server to third-party integration vignette (#835).
+-   Break the line between `%>%` and `{` inside and outside function calls
+    (#825).
 
-* improved test setup with fixtures and similar (#798).
+-   Add language server to third-party integration vignette (#835).
+
+-   improved test setup with fixtures and similar (#798).
 
 We'd like to thank all people who helped making this release possible:
 
-[&#x0040;bersbersbers](https://github.com/bersbersbers), [&#x0040;eutwt](https://github.com/eutwt), [&#x0040;IndrajeetPatil](https://github.com/IndrajeetPatil), [&#x0040;j-mammen](https://github.com/j-mammen), [&#x0040;jennybc](https://github.com/jennybc), [&#x0040;JohannesNE](https://github.com/JohannesNE), [&#x0040;jonkeane](https://github.com/jonkeane), [&#x0040;lorenzwalthert](https://github.com/lorenzwalthert), and [&#x0040;MichaelChirico](https://github.com/MichaelChirico).
-
+[\@bersbersbers](https://github.com/bersbersbers),
+[\@eutwt](https://github.com/eutwt),
+[\@IndrajeetPatil](https://github.com/IndrajeetPatil),
+[\@j-mammen](https://github.com/j-mammen),
+[\@jennybc](https://github.com/jennybc),
+[\@JohannesNE](https://github.com/JohannesNE),
+[\@jonkeane](https://github.com/jonkeane),
+[\@lorenzwalthert](https://github.com/lorenzwalthert), and
+[\@MichaelChirico](https://github.com/MichaelChirico).
 
 # styler 1.5.1
 
 ## Alignment detection
 
-* Code with left alignment after `=` in function calls is now recognized as 
-  aligned and won't be reformatted (#774, #777).
-  ```
-  # already detected previously
-  call(
-    x  = 12345,
-    y2 =    17
-  )
-  
-  # newly detected
-  call(
-    x  = 12345,
-    y2 = 17
-  )
-  ```
+-   Code with left alignment after `=` in function calls is now recognized as
+    aligned and won't be reformatted (#774, #777).
 
-* Similarly, left aligned after comma is now detected (#785, #786).
-  ```
-  # previously detected
-  call(
-    x  = 12345, "It's old",
-    y2 = 17,      "before"
-  )
-  
-  tribble(
-    ~x,             ~y,
-    "another",     1:3,
-    "b",       1211234
-  )
-  
-  # newly detected
-  call(
-    x = 2,           p = "another",
-    y = "hhjkjkbew", x = 3
-  )
+        # already detected previously
+        call(
+          x  = 12345,
+          y2 =    17
+        )
 
-  
-  tribble(
-    ~x,        ~y,
-    "another", 1:3,
-    "b",       1211234
-  )
-  ```
-  Also see `vignette("detect-alignment")`.
+        # newly detected
+        call(
+          x  = 12345,
+          y2 = 17
+        )
+
+-   Similarly, left aligned after comma is now detected (#785, #786).
+
+        # previously detected
+        call(
+          x  = 12345, "It's old",
+          y2 = 17,      "before"
+        )
+
+        tribble(
+          ~x,             ~y,
+          "another",     1:3,
+          "b",       1211234
+        )
+
+        # newly detected
+        call(
+          x = 2,           p = "another",
+          y = "hhjkjkbew", x = 3
+        )
+
+
+        tribble(
+          ~x,        ~y,
+          "another", 1:3,
+          "b",       1211234
+        )
+
+    Also see `vignette("detect-alignment")`.
 
 ## Other new features
 
-* The base R pipe as introduced in R 4.1.0 is now styled the same way the 
-  magrittr pipe is (#803).
-* code chunks with explicit `tidy = FALSE` in an Rmd or Rnw code header are not 
-  styled anymore. This can be handy when the code can't be parsed, e.g.
-  within a learnr tutorial (#790).
-* `#>` is recognized as an output marker and no space is added after `#` (#771).
+-   The base R pipe as introduced in R 4.1.0 is now styled the same way the
+    magrittr pipe is (#803).
+-   code chunks with explicit `tidy = FALSE` in an Rmd or Rnw code header are
+    not styled anymore. This can be handy when the code can't be parsed, e.g.
+    within a learnr tutorial (#790).
+-   `#>` is recognized as an output marker and no space is added after `#`
+    (#771).
 
 ## Minor changes and fixes
 
-* No curly braces are added to else statements if they are within a pipe, as 
-  this can change evaluation logic of code involving the magrittr dot in rare 
-  cases (#816).
-* Line breaks between `}` and `else` are removed (#793).
-* In function calls, code after `= #\n` is indented correctly (#814).
-* Multi-expressions containing multiple assignments no longer remove line breaks
-  if they are not causing blank lines (#809).
-* `exclude_dirs` in `style_pkg()` is now properly respected if it is a 
-  sub-directory of a directory that is scheduled for styling (e.g. 
-  `test/testthat/some/dir`) (#811).
-* The user is not prompted anymore to confirm the creation of a permanent cache 
-  as R.cache >= 0.15.0 uses a standard location in line with CRAN policies 
-  (#819).
-* R code chunks in nested non-R chunks in R markdown don't yield an error 
-  anymore when document is styled, chunks are still not styled (#788, #794).
-* `cache_activate()` and `cache_deactivate()` now respect the R 
-  option `styler.quiet` (#797).
-* `multi_line` attribute in parse table is now integer, not boolean (#782).
-* The style guide used in Addin is verified when set via R option (#789).
-* Improve pkgdown author URLs (#775).
-* Upgrade touchstone infra (#799, #805).
-* Don't test on R 3.3 anymore as tidyverse [supports only four previous
-  releases](https://www.tidyverse.org/blog/2019/04/r-version-support/) (#804).
-* Update Github Actions workflow (#810).
+-   No curly braces are added to else statements if they are within a pipe, as
+    this can change evaluation logic of code involving the magrittr dot in rare
+    cases (#816).
+-   Line breaks between `}` and `else` are removed (#793).
+-   In function calls, code after `= #\n` is indented correctly (#814).
+-   Multi-expressions containing multiple assignments no longer remove line
+    breaks if they are not causing blank lines (#809).
+-   `exclude_dirs` in `style_pkg()` is now properly respected if it is a
+    sub-directory of a directory that is scheduled for styling (e.g.
+    `test/testthat/some/dir`) (#811).
+-   The user is not prompted anymore to confirm the creation of a permanent
+    cache as R.cache \>= 0.15.0 uses a standard location in line with CRAN
+    policies (#819).
+-   R code chunks in nested non-R chunks in R markdown don't yield an error
+    anymore when document is styled, chunks are still not styled (#788, #794).
+-   `cache_activate()` and `cache_deactivate()` now respect the R option
+    `styler.quiet` (#797).
+-   `multi_line` attribute in parse table is now integer, not boolean (#782).
+-   The style guide used in Addin is verified when set via R option (#789).
+-   Improve pkgdown author URLs (#775).
+-   Upgrade touchstone infra (#799, #805).
+-   Don't test on R 3.3 anymore as tidyverse [supports only four previous
+    releases](https://www.tidyverse.org/blog/2019/04/r-version-support/)
+    (#804).
+-   Update Github Actions workflow (#810).
 
-We’d like to thank everyone who has furthered the development of the latest 
+We'd like to thank everyone who has furthered the development of the latest
 release of styler through their contributions in issues and pull requests:
 
-[&#x0040;ardydavari](https://github.com/ardydavari), 
-[&#x0040;gadenbuie](https://github.com/gadenbuie), [&#x0040;IndrajeetPatil](https://github.com/IndrajeetPatil), &#x0040;jasonhan-vassar, [&#x0040;laresbernardo](https://github.com/laresbernardo), [&#x0040;lorenzwalthert](https://github.com/lorenzwalthert), [&#x0040;MichaelChirico](https://github.com/MichaelChirico), 
-[&#x0040;Moohan](https://github.com/Moohan), 
-[&#x0040;njtierney](https://github.com/njtierney), 
-[&#x0040;pat-s](https://github.com/pat-s),
-[&#x0040;psychelzh](https://github.com/psychelzh),
-[&#x0040;pvalders](https://github.com/pvalders), 
-[&#x0040;RoyalTS](https://github.com/RoyalTS), and 
-[&#x0040;russHyde](https://github.com/russHyde).
+[\@ardydavari](https://github.com/ardydavari),
+[\@gadenbuie](https://github.com/gadenbuie),
+[\@IndrajeetPatil](https://github.com/IndrajeetPatil), \@jasonhan-vassar,
+[\@laresbernardo](https://github.com/laresbernardo),
+[\@lorenzwalthert](https://github.com/lorenzwalthert),
+[\@MichaelChirico](https://github.com/MichaelChirico),
+[\@Moohan](https://github.com/Moohan),
+[\@njtierney](https://github.com/njtierney),
+[\@pat-s](https://github.com/pat-s),
+[\@psychelzh](https://github.com/psychelzh),
+[\@pvalders](https://github.com/pvalders),
+[\@RoyalTS](https://github.com/RoyalTS), and
+[\@russHyde](https://github.com/russHyde).
 
 # styler 1.4.1
 
-* fix interaction between cache and `base_indention`. This also fixes
-  the Addin for styling a selection with base indention repeatedly (#764).
-* add more examples to `styler_*` helpfiles (#762).
-* hexadecimal integers now preserve the trailing `L` when styled (#761).
-* add a pre-push hook to make sure news bullets are added to each PR (#765).
+-   fix interaction between cache and `base_indention`. This also fixes the
+    Addin for styling a selection with base indention repeatedly (#764).
+-   add more examples to `styler_*` helpfiles (#762).
+-   hexadecimal integers now preserve the trailing `L` when styled (#761).
+-   add a pre-push hook to make sure news bullets are added to each PR (#765).
 
 Thanks to everyone who contributed to this release:
 
-[&#x0040;krlmlr](https://github.com/krlmlr), [&#x0040;lorenzwalthert](https://github.com/lorenzwalthert), and [&#x0040;renkun-ken](https://github.com/renkun-ken).
+[\@krlmlr](https://github.com/krlmlr),
+[\@lorenzwalthert](https://github.com/lorenzwalthert), and
+[\@renkun-ken](https://github.com/renkun-ken).
 
 # styler 1.4.0
 
@@ -257,118 +306,143 @@ Thanks to everyone who contributed to this release:
 
 **new**
 
-- `style_file()` and friends gain argument `dry` to control if changes should be
-  applied to files or not (#634).
+-   `style_file()` and friends gain argument `dry` to control if changes should
+    be applied to files or not (#634).
 
-- `style_file()` and friends gain argument `base_indention` (defaulting to 0) to
-  control by how much the output code is indented (#649, #692). The Addin for
-  styling a selection picks that up, e.g. you can style a function body and
-  indention is preserved (#725).
+-   `style_file()` and friends gain argument `base_indention` (defaulting to 0)
+    to control by how much the output code is indented (#649, #692). The Addin
+    for styling a selection picks that up, e.g. you can style a function body
+    and indention is preserved (#725).
 
-- added an option for disabling all communication when using the package
-  (`styler.quiet`) (#640).
+-   added an option for disabling all communication when using the package
+    (`styler.quiet`) (#640).
 
-- `scope` in `tidyverse_style()` can now be specified with higher granularity
-  through `I()`, e.g. `I(c('spaces', 'tokens'))` allows us to style spaces and
-  tokens without styling line breaks and indention. Previously, only a string
-  was allowed and all less invasive scopes were included, e.g. if you wanted to
-  style tokens, you had to always also style spaces, indention, line breaks as
-  well (#705, #707).
+-   `scope` in `tidyverse_style()` can now be specified with higher granularity
+    through `I()`, e.g. `I(c('spaces', 'tokens'))` allows us to style spaces
+    and tokens without styling line breaks and indention. Previously, only a
+    string was allowed and all less invasive scopes were included, e.g. if you
+    wanted to style tokens, you had to always also style spaces, indention,
+    line breaks as well (#705, #707).
 
-- added an option (`styler.test_dir_writeable`) that changes test behavior to
-  not directly modify test files in the current directory (#548).
+-   added an option (`styler.test_dir_writeable`) that changes test behavior to
+    not directly modify test files in the current directory (#548).
 
-- New argument `transformers_drop` in `create_style_guide()` to be populated
-  with new helper function `specify_transformers_drop()` for specifying
-  conditions under which transformers are not going to be used and can therefore
-  be omitted without effecting the result of styling (#711).
+-   New argument `transformers_drop` in `create_style_guide()` to be populated
+    with new helper function `specify_transformers_drop()` for specifying
+    conditions under which transformers are not going to be used and can
+    therefore be omitted without effecting the result of styling (#711).
 
 **deprecated**
 
-- The environment variable `save_after_styling` is deprecated in favor of the R
-  option `styler.save_after_styling` to control if a file is saved after styling
-  with the RStudio Addin. Note than in RStudio >= 1.3.0, you can auto-save edits
-  in general (Code -> Saving -> Auto-Save), e.g. on idle editor or focus loss,
-  so this feature becomes less relevant (#631, #726).
-
+-   The environment variable `save_after_styling` is deprecated in favor of the
+    R option `styler.save_after_styling` to control if a file is saved after
+    styling with the RStudio Addin. Note than in RStudio \>= 1.3.0, you can
+    auto-save edits in general (Code -\> Saving -\> Auto-Save), e.g. on idle
+    editor or focus loss, so this feature becomes less relevant (#631, #726).
 
 ## Major changes
 
-- styler is now distributed under the MIT license (#751).
+-   styler is now distributed under the MIT license (#751).
 
-- Documentation overhaul: New README, new "Get started" pkgdown page, new
-  vignettes on `strict = FALSE`, `Adoption` renamed to `Third-party
-  integrations` (#741), adding search to pkgdown (#623), group functions in
-  pkgdown reference page (#625), minor other doc improvements (#643, #618, #614,
-  #677, #651, #667, #672, #687, #752, #754).
+-   Documentation overhaul: New README, new "Get started" pkgdown page, new
+    vignettes on `strict = FALSE`, `Adoption` renamed to
+    `Third-party   integrations` (#741), adding search to pkgdown (#623), group
+    functions in pkgdown reference page (#625), minor other doc improvements
+    (#643, #618, #614, #677, #651, #667, #672, #687, #752, #754).
 
-- `@exampleIsf` roxygen tag for conditional examples is now supported (#743).
+-   `@exampleIsf` roxygen tag for conditional examples is now supported (#743).
 
-- blank lines in function calls and headers are now removed, for the former only
-  when there are no comments before or after the blank line (#629, #630, #635,
-  #723).
+-   blank lines in function calls and headers are now removed, for the former
+    only when there are no comments before or after the blank line (#629, #630,
+    #635, #723).
 
-- speed improvements: 15% faster on new code, 70% on repeated styling of 
-  compliant code (The latter is not so relevant because it was almost 
-  instantaneous already). Most relevant contributions were #679, #691, #681, 
-  #711, #739.
+-   speed improvements: 15% faster on new code, 70% on repeated styling of
+    compliant code (The latter is not so relevant because it was almost
+    instantaneous already). Most relevant contributions were #679, #691, #681,
+    #711, #739.
 
-- `#<<` is now recognized as the xaringan marker and no space is added after`#`
-  (#700).
+-   `#<<` is now recognized as the xaringan marker and no space is added
+    after`#` (#700).
 
 ## Minor changes and fixes
 
-- `style_dir()` and `style_pkg()` now apply directory exclusion recursively with
-  `exclude_dirs` (#676).
+-   `style_dir()` and `style_pkg()` now apply directory exclusion recursively
+    with `exclude_dirs` (#676).
 
-- `switch()` now has line breaks after every argument to match the tidyverse
-  style guide (#722, #727).
+-   `switch()` now has line breaks after every argument to match the tidyverse
+    style guide (#722, #727).
 
-- unary `+` before a function call does not give an error anymore, as before
-  version 1.3.0 (#697).
+-   unary `+` before a function call does not give an error anymore, as before
+    version 1.3.0 (#697).
 
-- certain combinations of `stylerignore` markers and cached expressions now
-  don't give an error anymore (#738).
+-   certain combinations of `stylerignore` markers and cached expressions now
+    don't give an error anymore (#738).
 
-- cache is now correctly invalidated when style guide arguments change (#647).
+-   cache is now correctly invalidated when style guide arguments change
+    (#647).
 
-- empty lines are now removed between pipes and assignments (#645, #710).
+-   empty lines are now removed between pipes and assignments (#645, #710).
 
-- multiple `@examples` roxygen tags in a code block of `#'` are no longer
-  squashed (#748).
+-   multiple `@examples` roxygen tags in a code block of `#'` are no longer
+    squashed (#748).
 
-- roxygen code examples starting on the same line as the `@examples` tag are no
-  longer moved to the next line (#748).
+-   roxygen code examples starting on the same line as the `@examples` tag are
+    no longer moved to the next line (#748).
 
-- always strip trailing spaces and make cache insensitive to it (#626).
+-   always strip trailing spaces and make cache insensitive to it (#626).
 
-- `style_text()` can now style all input that `is.character()`, not just if it
-  inherits from classes `character`, `utf8` or `vertical` (#693).
+-   `style_text()` can now style all input that `is.character()`, not just if
+    it inherits from classes `character`, `utf8` or `vertical` (#693).
 
-- logical operators within square braces are now moved from the start of a line
-  to the end of the previous line (#709).
+-   logical operators within square braces are now moved from the start of a
+    line to the end of the previous line (#709).
 
-- spaces are now removed before `[` and `[[` (#713).
+-   spaces are now removed before `[` and `[[` (#713).
 
-- The internal `create_tree()` only used in testing of styler now works when the
-  cache is activated (#688).
+-   The internal `create_tree()` only used in testing of styler now works when
+    the cache is activated (#688).
 
-- simplification of internals (#692).
+-   simplification of internals (#692).
 
 ## Infrastructure changes
 
-- switched from travis and AppVeyor to GitHub Actions (#653, #660).
+-   switched from travis and AppVeyor to GitHub Actions (#653, #660).
 
-- Added basic continuous benchmarking with
-  [lorenzwalthert/touchstone](https://github.com/lorenzwalthert/touchstone)
-  (#674, #684, #698).
+-   Added basic continuous benchmarking with
+    [lorenzwalthert/touchstone](https://github.com/lorenzwalthert/touchstone)
+    (#674, #684, #698).
 
-- include `test-*` files in styling pre-commit hook (#724).
-
+-   include `test-*` files in styling pre-commit hook (#724).
 
 Thanks to all the people who made this release possible:
 
-[&#x0040;assignUser](https://github.com/assignUser), [&#x0040;ColmanHumphrey](https://github.com/ColmanHumphrey), [&#x0040;davidchall](https://github.com/davidchall), [&#x0040;espinielli](https://github.com/espinielli), [&#x0040;giko45](https://github.com/giko45), [&#x0040;hadley](https://github.com/hadley), [&#x0040;IndrajeetPatil](https://github.com/IndrajeetPatil), [&#x0040;intiben](https://github.com/intiben), [&#x0040;jamespeapen](https://github.com/jamespeapen), [&#x0040;jthomasmock](https://github.com/jthomasmock), [&#x0040;Kalaschnik](https://github.com/Kalaschnik), [&#x0040;kevinushey](https://github.com/kevinushey), [&#x0040;krlmlr](https://github.com/krlmlr), [&#x0040;lcolladotor](https://github.com/lcolladotor), [&#x0040;MichaelChirico](https://github.com/MichaelChirico), [&#x0040;michaelquinn32](https://github.com/michaelquinn32), [&#x0040;mine-cetinkaya-rundel](https://github.com/mine-cetinkaya-rundel), [&#x0040;pat-s](https://github.com/pat-s), [&#x0040;PMassicotte](https://github.com/PMassicotte), [&#x0040;QuLogic](https://github.com/QuLogic), [&#x0040;renkun-ken](https://github.com/renkun-ken), [&#x0040;RichardJActon](https://github.com/RichardJActon), [&#x0040;seed-of-apricot](https://github.com/seed-of-apricot), [&#x0040;select-id-from-users](https://github.com/select-id-from-users), [&#x0040;SimonDedman](https://github.com/SimonDedman), [&#x0040;stefanoborini](https://github.com/stefanoborini), [&#x0040;swsoyee](https://github.com/swsoyee), and [&#x0040;Winterstorm-j](https://github.com/Winterstorm-j).
+[\@assignUser](https://github.com/assignUser),
+[\@ColmanHumphrey](https://github.com/ColmanHumphrey),
+[\@davidchall](https://github.com/davidchall),
+[\@espinielli](https://github.com/espinielli),
+[\@giko45](https://github.com/giko45), [\@hadley](https://github.com/hadley),
+[\@IndrajeetPatil](https://github.com/IndrajeetPatil),
+[\@intiben](https://github.com/intiben),
+[\@jamespeapen](https://github.com/jamespeapen),
+[\@jthomasmock](https://github.com/jthomasmock),
+[\@Kalaschnik](https://github.com/Kalaschnik),
+[\@kevinushey](https://github.com/kevinushey),
+[\@krlmlr](https://github.com/krlmlr),
+[\@lcolladotor](https://github.com/lcolladotor),
+[\@MichaelChirico](https://github.com/MichaelChirico),
+[\@michaelquinn32](https://github.com/michaelquinn32),
+[\@mine-cetinkaya-rundel](https://github.com/mine-cetinkaya-rundel),
+[\@pat-s](https://github.com/pat-s),
+[\@PMassicotte](https://github.com/PMassicotte),
+[\@QuLogic](https://github.com/QuLogic),
+[\@renkun-ken](https://github.com/renkun-ken),
+[\@RichardJActon](https://github.com/RichardJActon),
+[\@seed-of-apricot](https://github.com/seed-of-apricot),
+[\@select-id-from-users](https://github.com/select-id-from-users),
+[\@SimonDedman](https://github.com/SimonDedman),
+[\@stefanoborini](https://github.com/stefanoborini),
+[\@swsoyee](https://github.com/swsoyee), and
+[\@Winterstorm-j](https://github.com/Winterstorm-j).
 
 # styler 1.3.2
 
@@ -376,154 +450,172 @@ Release upon request by the CRAN team.
 
 ## Minor changes and fixes
 
-- Add search and reference sections to pkgdown webpage (#623, #625).
-- various fixes to handle special cases for caching and stylerignore and their
-  interaction (#611, #610, #609, #607, #602, #600).
-- also test on macOS (#604).
-- skip timing tests on CRAN as requested by CRAN team because they did not pass 
-  on all machines (#603).
+-   Add search and reference sections to pkgdown webpage (#623, #625).
+-   various fixes to handle special cases for caching and stylerignore and
+    their interaction (#611, #610, #609, #607, #602, #600).
+-   also test on macOS (#604).
+-   skip timing tests on CRAN as requested by CRAN team because they did not
+    pass on all machines (#603).
 
 # styler 1.3.1
 
-Emergency release. In case multiple expressions are on one line and only 
-some of them are cached, styler can remove code. To reach this state, 
-some of the expressions must have been styled previously alone and the cache
-must be active. Example:
+Emergency release. In case multiple expressions are on one line and only some
+of them are cached, styler can remove code. To reach this state, some of the
+expressions must have been styled previously alone and the cache must be
+active. Example:
 
-```
-library(styler)
-cache_activate()
-#> Using cache 1.3.0 at ~/.Rcache/styler/1.3.0.
-style_text("1")
-#> 1
-style_text("1 # comment")
-#> # comment
-```
+    library(styler)
+    cache_activate()
+    #> Using cache 1.3.0 at ~/.Rcache/styler/1.3.0.
+    style_text("1")
+    #> 1
+    style_text("1 # comment")
+    #> # comment
 
-This is obviously detrimental. We have added additional tests and fixed the 
-problem (#593, #595), but we want repeat the warning from `?style_file` that all 
-style APIs apart from `style_text()` overwrite code and that styler can only 
-check the AST remains valid with `scope < "tokens"`. So use this if you are 
-conservative. Or deactivate the cache with `deactivate_cache()` until it has 
-fully matured.
+This is obviously detrimental. We have added additional tests and fixed the
+problem (#593, #595), but we want repeat the warning from `?style_file` that
+all style APIs apart from `style_text()` overwrite code and that styler can
+only check the AST remains valid with `scope < "tokens"`. So use this if you
+are conservative. Or deactivate the cache with `deactivate_cache()` until it
+has fully matured.
 
 We thank the people who have contributed to this release:
 
-[&#x0040;ellessenne](https://github.com/ellessenne) and 
-[&#x0040;renkun-ken](https://github.com/renkun-ken).
+[\@ellessenne](https://github.com/ellessenne) and
+[\@renkun-ken](https://github.com/renkun-ken).
 
 # styler 1.3.0
 
 ## Breaking changes
 
-* `style_pkg()` and `style_dir()` gain a new argument `exclude_dirs` to exclude
-  directories from styling, by default `renv` and `packrat`. Note that the
-  defaults won't change the behavior of `style_pkg()` because it does anyways
-  does not style these directories and they were set for consistency.
+-   `style_pkg()` and `style_dir()` gain a new argument `exclude_dirs` to
+    exclude directories from styling, by default `renv` and `packrat`. Note
+    that the defaults won't change the behavior of `style_pkg()` because it
+    does anyways does not style these directories and they were set for
+    consistency.
 
-* `style_file()` and friends now strip `./` in file paths returned invisibly, 
-  i.e. `./script.R` becomes `script.R` (#568).
+-   `style_file()` and friends now strip `./` in file paths returned invisibly,
+    i.e. `./script.R` becomes `script.R` (#568).
 
 ## New features
 
-* ignore certain lines using `# styler: off` and `#styler: on` or custom
-  markers, see `?stylerignore` (#560).
+-   ignore certain lines using `# styler: off` and `#styler: on` or custom
+    markers, see `?stylerignore` (#560).
 
-* styler caches results of styling, so applying styler to code it has styled
-  before will be instantaneous. This brings large speed boosts in many
-  situations, e.g. when `style_pkg()` is run but only a few files have changed
-  since the last styling or when using the [styler pre-commit
-  hook](https://github.com/lorenzwalthert/precommit). Because styler caches by
-  expression, you will also get speed boosts in large files with many
-  expressions when you only change a few of them. See `?caching` for details
-  (#538, #578).
+-   styler caches results of styling, so applying styler to code it has styled
+    before will be instantaneous. This brings large speed boosts in many
+    situations, e.g. when `style_pkg()` is run but only a few files have
+    changed since the last styling or when using the [styler pre-commit
+    hook](https://github.com/lorenzwalthert/precommit). Because styler caches
+    by expression, you will also get speed boosts in large files with many
+    expressions when you only change a few of them. See `?caching` for details
+    (#538, #578).
 
-* `create_style_guide()` gains two arguments `style_guide_name` and
-  `style_guide_version` that are carried as meta data, in particular to version
-  third-party style guides and ensure the proper functioning of caching. This
-  change is completely invisible to users who don't create and distribute their
-  own style guide like `tidyverse_style()` (#572).
+-   `create_style_guide()` gains two arguments `style_guide_name` and
+    `style_guide_version` that are carried as meta data, in particular to
+    version third-party style guides and ensure the proper functioning of
+    caching. This change is completely invisible to users who don't create and
+    distribute their own style guide like `tidyverse_style()` (#572).
 
 ## Minor changes and fixes
 
-* lines are now broken after `+` in `ggplot2` calls for `strict = TRUE` (#569).
+-   lines are now broken after `+` in `ggplot2` calls for `strict = TRUE`
+    (#569).
 
-* function documentation now contains many more line breaks due to roxygen2 
-  update to version 7.0.1 (#566).
+-   function documentation now contains many more line breaks due to roxygen2
+    update to version 7.0.1 (#566).
 
-* spaces next to the braces in subsetting expressions `[` and `[[` are now
-  removed (#580).
+-   spaces next to the braces in subsetting expressions `[` and `[[` are now
+    removed (#580).
 
-* Adapt to changes in the R parser to make styler pass R CMD check again.
-  (#583).
+-   Adapt to changes in the R parser to make styler pass R CMD check again.
+    (#583).
 
 Thanks to all contributors involved, in particular
-[&#x0040;colearendt](https://github.com/colearendt), 
-[&#x0040;davidski](https://github.com/davidski), 
-[&#x0040;IndrajeetPatil](https://github.com/IndrajeetPatil), 
-[&#x0040;pat-s](https://github.com/pat-s), and 
-[&#x0040;programming-wizard](https://github.com).
+[\@colearendt](https://github.com/colearendt),
+[\@davidski](https://github.com/davidski),
+[\@IndrajeetPatil](https://github.com/IndrajeetPatil),
+[\@pat-s](https://github.com/pat-s), and
+[\@programming-wizard](https://github.com).
 
 # styler 1.2.0
 
 ## Breaking changes
 
-* `style_file()` now correctly styles multiple files from different directories.
-  We no longer display the file name of the styled file, but the absolute path.
-  This is also reflected in the invisible return value of the function (#522).
+-   `style_file()` now correctly styles multiple files from different
+    directories. We no longer display the file name of the styled file, but the
+    absolute path. This is also reflected in the invisible return value of the
+    function (#522).
 
-* `style_file()` and friends do not write content back to a file when styling
-  does not cause any changes in the file. This means the modification date of
-  styled files is only changed when the content is changed (#532).
+-   `style_file()` and friends do not write content back to a file when styling
+    does not cause any changes in the file. This means the modification date of
+    styled files is only changed when the content is changed (#532).
 
 ## New features
 
-* Aligned function calls are detected and remain unchanged if they match the
-  styler [definition for aligned function
-  calls](https://styler.r-lib.org/articles/detect-alignment.html) (#537).
+-   Aligned function calls are detected and remain unchanged if they match the
+    styler [definition for aligned function
+    calls](https://styler.r-lib.org/articles/detect-alignment.html) (#537).
 
-* curly-curly (`{{`) syntactic sugar introduced with rlang 0.4.0 is now
-  explicitly handled, where previously it was just treated as two consecutive
-  curly braces (#528).
+-   curly-curly (`{{`) syntactic sugar introduced with rlang 0.4.0 is now
+    explicitly handled, where previously it was just treated as two consecutive
+    curly braces (#528).
 
-* `style_pkg()`, `style_dir()` and the Addins can now style `.Rprofile`, and
-  hidden files are now also styled (#530).
+-   `style_pkg()`, `style_dir()` and the Addins can now style `.Rprofile`, and
+    hidden files are now also styled (#530).
 
 ## Minor improvements and fixes
 
-* Roxygen code examples: leverage `roxygen2` for correct
-  escaping of expressions that contain `\`, in particular in `dontrun{}` and 
-  friends, allow quoted braces that are not matched (#729).
-  
-* Brace expressions in function calls are formatted in a less compact way to
-  improve readability. Typical use case: `tryCatch()` (#543).
+-   Roxygen code examples: leverage `roxygen2` for correct escaping of
+    expressions that contain `\`, in particular in `dontrun{}` and friends,
+    allow quoted braces that are not matched (#729).
 
-* Arguments in function declarations in a context which is indented multiple
-  times should now be correct. This typically affects `R6::R6Class()` (#546).
+-   Brace expressions in function calls are formatted in a less compact way to
+    improve readability. Typical use case: `tryCatch()` (#543).
 
-* Escape characters in roxygen code examples are now correctly escaped (#512).
+-   Arguments in function declarations in a context which is indented multiple
+    times should now be correct. This typically affects `R6::R6Class()` (#546).
 
-* Special characters such as `\n` in strings are now preserved in text and not
-  turned into literal values like a line break (#554).
+-   Escape characters in roxygen code examples are now correctly escaped
+    (#512).
 
-* Style selection Addin now preserves line break when the last line selected is
-  an entire line (#520).
+-   Special characters such as `\n` in strings are now preserved in text and
+    not turned into literal values like a line break (#554).
 
-* Style file Addin can now properly handle cancelling (#511).
+-   Style selection Addin now preserves line break when the last line selected
+    is an entire line (#520).
 
-* The body of a multi-line function declaration is now indented correctly for
-  `strict = FALSE` and also wrapped in curly braces for `strict = TRUE` (#536).
+-   Style file Addin can now properly handle cancelling (#511).
 
-* Advice for contributors in `CONTRIBUTING.md` was updated (#508).
+-   The body of a multi-line function declaration is now indented correctly for
+    `strict = FALSE` and also wrapped in curly braces for `strict = TRUE`
+    (#536).
+
+-   Advice for contributors in `CONTRIBUTING.md` was updated (#508).
 
 ## Adaption
 
-* styler is now available through the pre-commit hook `style-files` in
-  https://github.com/lorenzwalthert/pre-commit-hooks.
+-   styler is now available through the pre-commit hook `style-files` in
+    <https://github.com/lorenzwalthert/pre-commit-hooks>.
 
 Thanks to all contributors involved, in particular
 
-[&#x0040;Banana1530](https://github.com/Banana1530), [&#x0040;batpigandme](https://github.com/batpigandme), [&#x0040;cpsievert](https://github.com/cpsievert), [&#x0040;ellessenne](https://github.com/ellessenne), [&#x0040;Emiller88](https://github.com/Emiller88), [&#x0040;hadley](https://github.com/hadley), [&#x0040;IndrajeetPatil](https://github.com/IndrajeetPatil), [&#x0040;krlmlr](https://github.com/krlmlr), [&#x0040;lorenzwalthert](https://github.com/lorenzwalthert), [&#x0040;lwjohnst86](https://github.com/lwjohnst86), [&#x0040;michaelquinn32](https://github.com/michaelquinn32), [&#x0040;mine-cetinkaya-rundel](https://github.com/mine-cetinkaya-rundel), [&#x0040;Moohan](https://github.com/Moohan), [&#x0040;nxskok](https://github.com/nxskok), [&#x0040;oliverbeagley](https://github.com/oliverbeagley), [&#x0040;pat-s](https://github.com/pat-s), &#x0040;reddy-ia, and [&#x0040;russHyde](https://github.com/russHyde)
+[\@Banana1530](https://github.com/Banana1530),
+[\@batpigandme](https://github.com/batpigandme),
+[\@cpsievert](https://github.com/cpsievert),
+[\@ellessenne](https://github.com/ellessenne),
+[\@Emiller88](https://github.com/Emiller88),
+[\@hadley](https://github.com/hadley),
+[\@IndrajeetPatil](https://github.com/IndrajeetPatil),
+[\@krlmlr](https://github.com/krlmlr),
+[\@lorenzwalthert](https://github.com/lorenzwalthert),
+[\@lwjohnst86](https://github.com/lwjohnst86),
+[\@michaelquinn32](https://github.com/michaelquinn32),
+[\@mine-cetinkaya-rundel](https://github.com/mine-cetinkaya-rundel),
+[\@Moohan](https://github.com/Moohan), [\@nxskok](https://github.com/nxskok),
+[\@oliverbeagley](https://github.com/oliverbeagley),
+[\@pat-s](https://github.com/pat-s), \@reddy-ia, and
+[\@russHyde](https://github.com/russHyde)
 
 # styler 1.1.1
 
@@ -532,89 +624,87 @@ This is primarily a maintenance release upon the request of the CRAN team
 
 ## Major changes
 
-- Users can now control style configurations for styler Addins (#463, #500),
-  using the `Set style` Addin. See `?styler::styler_addins` for details.
+-   Users can now control style configurations for styler Addins (#463, #500),
+    using the `Set style` Addin. See `?styler::styler_addins` for details.
 
-- `return()` is now always put in braces and put on a new line when used in a
-  conditional statement (#492).
+-   `return()` is now always put in braces and put on a new line when used in a
+    conditional statement (#492).
 
-- `%>%` almost always causes a line break now for `strict = TRUE` (#503).
+-   `%>%` almost always causes a line break now for `strict = TRUE` (#503).
 
 ## Minor changes
 
-- `style_pkg()` now also styles the "demo" directory by default (#453).
+-   `style_pkg()` now also styles the "demo" directory by default (#453).
 
-- multi-line strings are now styled more consistently (#459).
+-   multi-line strings are now styled more consistently (#459).
 
-- indention in roxygen code example styling (#455) and EOF spacing (#469) was
-  fixed.
+-   indention in roxygen code example styling (#455) and EOF spacing (#469) was
+    fixed.
 
-- indention for for loop edge case (#457) and comments in pipe chain (#482) were
-  fixed.
+-   indention for for loop edge case (#457) and comments in pipe chain (#482)
+    were fixed.
 
-- line-break styling around comma is improved (#479).
+-   line-break styling around comma is improved (#479).
 
-- bug that can cause an error when the variable `text` in any name space before
-  styler on the search path was defined and did not have length 1 is fixed
-  (#484).
+-   bug that can cause an error when the variable `text` in any name space
+    before styler on the search path was defined and did not have length 1 is
+    fixed (#484).
 
-- slightly confusing warning about empty strings caused with roxygen code
-  examples and Rmd was removed.
+-   slightly confusing warning about empty strings caused with roxygen code
+    examples and Rmd was removed.
 
-- right apostrophe to let package pass R CMD Check in strict Latin-1 locale was
-  removed (#490, reason for release).
+-   right apostrophe to let package pass R CMD Check in strict Latin-1 locale
+    was removed (#490, reason for release).
 
 ## Adaption of styler
 
-Since it's never been mentioned in the release notes, we also mention here where
-else you can use styler functionality:
+Since it's never been mentioned in the release notes, we also mention here
+where else you can use styler functionality:
 
-* `usethis::use_tidy_style()` styles your project according to the tidyverse
-  style guide.
+-   `usethis::use_tidy_style()` styles your project according to the tidyverse
+    style guide.
 
-* `reprex::reprex(style = TRUE)` to prettify reprex code before printing. To
-  permanently use `style = TRUE` without specifying it every time, you can add
-  the following line to your `.Rprofile` (via `usethis::edit_r_profile()`):
-  `options(reprex.styler = TRUE)`.
+-   `reprex::reprex(style = TRUE)` to prettify reprex code before printing. To
+    permanently use `style = TRUE` without specifying it every time, you can
+    add the following line to your `.Rprofile` (via
+    `usethis::edit_r_profile()`): `options(reprex.styler = TRUE)`.
 
-* you can pretty-print your R code in RMarkdown reports without having styler
-  modifying the source. This feature is implemented as a code chunk option in
-  knitr. use `tidy = "styler"` in the header of a code chunks (e.g. ` ```{r
-  name-of-the-chunk, tidy = "styler"}`), or `knitr::opts_chunk$set(tidy =
-  "styler")` at the top of your RMarkdown script.
+-   you can pretty-print your R code in RMarkdown reports without having styler
+    modifying the source. This feature is implemented as a code chunk option in
+    knitr. use `tidy = "styler"` in the header of a code chunks (e.g.
+    ```` ```{r   name-of-the-chunk, tidy = "styler"} ````), or
+    `knitr::opts_chunk$set(tidy =   "styler")` at the top of your RMarkdown
+    script.
 
-* pretty-printing of [drake](https://github.com/ropensci/drake) workflow data
-  frames with `drake::drake_plan_source()`.
+-   pretty-printing of [drake](https://github.com/ropensci/drake) workflow data
+    frames with `drake::drake_plan_source()`.
 
-* Adding styler as a fixer to the [ale
-  Plug-in](https://github.com/dense-analysis/ale/pull/2401) for
-  VIM.
+-   Adding styler as a fixer to the [ale
+    Plug-in](https://github.com/dense-analysis/ale/pull/2401) for VIM.
 
 Thanks to all contributors involved, in particular
-[&#x0040;ArthurPERE](https://github.com/ArthurPERE),
-[&#x0040;hadley](https://github.com/hadley),
-[&#x0040;igordot](https://github.com/igordot),
-[&#x0040;IndrajeetPatil](https://github.com/IndrajeetPatil),
-[&#x0040;jackwasey](https://github.com/jackwasey),
-[&#x0040;jcrodriguez1989](https://github.com/jcrodriguez1989),
-[&#x0040;jennybc](https://github.com/jennybc),
-[&#x0040;jonmcalder](https://github.com/jonmcalder),
-[&#x0040;katrinleinweber](https://github.com/katrinleinweber),
-[&#x0040;krlmlr](https://github.com/krlmlr),
-[&#x0040;lorenzwalthert](https://github.com/lorenzwalthert),
-[&#x0040;michaelquinn32](https://github.com/michaelquinn32),
-[&#x0040;msberends](https://github.com/msberends),
-[&#x0040;raynamharris](https://github.com/raynamharris),
-[&#x0040;riccardoporreca](https://github.com/riccardoporreca),
-[&#x0040;rjake](https://github.com/rjake),
-[&#x0040;Robinlovelace](https://github.com/Robinlovelace),
-[&#x0040;skirmer](https://github.com/skirmer),
-[&#x0040;thalesmello](https://github.com/thalesmello),
-[&#x0040;tobiasgerstenberg](https://github.com/tobiasgerstenberg),
-[&#x0040;tvatter](https://github.com/tvatter),
-[&#x0040;wdearden](https://github.com/wdearden),
-[&#x0040;wmayner](https://github.com/wmayner), and
-&#x0040;yech1990.
+[\@ArthurPERE](https://github.com/ArthurPERE),
+[\@hadley](https://github.com/hadley), [\@igordot](https://github.com/igordot),
+[\@IndrajeetPatil](https://github.com/IndrajeetPatil),
+[\@jackwasey](https://github.com/jackwasey),
+[\@jcrodriguez1989](https://github.com/jcrodriguez1989),
+[\@jennybc](https://github.com/jennybc),
+[\@jonmcalder](https://github.com/jonmcalder),
+[\@katrinleinweber](https://github.com/katrinleinweber),
+[\@krlmlr](https://github.com/krlmlr),
+[\@lorenzwalthert](https://github.com/lorenzwalthert),
+[\@michaelquinn32](https://github.com/michaelquinn32),
+[\@msberends](https://github.com/msberends),
+[\@raynamharris](https://github.com/raynamharris),
+[\@riccardoporreca](https://github.com/riccardoporreca),
+[\@rjake](https://github.com/rjake),
+[\@Robinlovelace](https://github.com/Robinlovelace),
+[\@skirmer](https://github.com/skirmer),
+[\@thalesmello](https://github.com/thalesmello),
+[\@tobiasgerstenberg](https://github.com/tobiasgerstenberg),
+[\@tvatter](https://github.com/tvatter),
+[\@wdearden](https://github.com/wdearden),
+[\@wmayner](https://github.com/wmayner), and \@yech1990.
 
 # styler 1.1.0
 
@@ -623,34 +713,34 @@ adapts to changes in the R parser committed into R devel (#419).
 
 ## Major Changes
 
-* styler can now style roxygen code examples in the source code of package
-  (#332) as well as Rnw files (#431).
+-   styler can now style roxygen code examples in the source code of package
+    (#332) as well as Rnw files (#431).
 
-* the print method for the output of `style_text()` (`print.vertical()`) now
-  returns syntax-highlighted code by default, controllable via the option
-  `styler.colored_print.vertical` (#417).
+-   the print method for the output of `style_text()` (`print.vertical()`) now
+    returns syntax-highlighted code by default, controllable via the option
+    `styler.colored_print.vertical` (#417).
 
-* the README was redesigned (#413).
+-   the README was redesigned (#413).
 
-* semi-colon expression that contained multiple assignments was fixed (#404).
+-   semi-colon expression that contained multiple assignments was fixed (#404).
 
 ## Minor Changes
 
-* cursor position is remembered for styling via Addin (#416).
+-   cursor position is remembered for styling via Addin (#416).
 
-* adapt spacing around tilde for multi-token expressions(#424) and brace edge
-  case (#425).
+-   adapt spacing around tilde for multi-token expressions(#424) and brace edge
+    case (#425).
 
-* only add brackets to piped function call if RHS is a symbol (#422).
+-   only add brackets to piped function call if RHS is a symbol (#422).
 
-* increase coverage again to over 90% (#412).
+-   increase coverage again to over 90% (#412).
 
-* move rule that turns single quotes into double quotes to token modifier in
-  `tidyverse_style_guide() (#406).
+-   move rule that turns single quotes into double quotes to token modifier in
+    \`tidyverse_style_guide() (#406).
 
-* remove line-breaks before commas (#405).
+-   remove line-breaks before commas (#405).
 
-* removed package dependency enc in favor of xfun (#442).
+-   removed package dependency enc in favor of xfun (#442).
 
 Thanks to all contributors for patches, issues and the like: @jonmcalder,
 @krlmlr, @IndrajeetPatil, @kalibera, @Hasnep, @kiranmaiganji, @dirkschumacher,
@@ -662,26 +752,26 @@ This is a maintenance release without any breaking API changes.
 
 ## Major Changes
 
-* Fixed indention for named multi-line function calls (#372).
+-   Fixed indention for named multi-line function calls (#372).
 
-* Non-R code chunks in `.Rmd` files are now respected and won't get styled
-  (#386).
+-   Non-R code chunks in `.Rmd` files are now respected and won't get styled
+    (#386).
 
 ## Minor Changes
 
-* Fixing an edge case in which, if very long strings were present in the code,
-  tokens could be replaced with wrong text (#384).
+-   Fixing an edge case in which, if very long strings were present in the
+    code, tokens could be replaced with wrong text (#384).
 
-* Spacing around tilde in formulas depends now on whether there is a LHS in the
-  formula (#379).
+-   Spacing around tilde in formulas depends now on whether there is a LHS in
+    the formula (#379).
 
-* Spaces are now also added around `EQ_SUB` (`=`) (#380).
+-   Spaces are now also added around `EQ_SUB` (`=`) (#380).
 
-* Added `CONTRIBUTING.md` to outline guidelines for contributing to styler.
+-   Added `CONTRIBUTING.md` to outline guidelines for contributing to styler.
 
-* More informative error messages for parsing problems (#401, #400).
+-   More informative error messages for parsing problems (#401, #400).
 
-* Improved documentation (#387).
+-   Improved documentation (#387).
 
 Thanks to all contributors for patches, issues and the like: @katrinleinweber,
 @krlmlr, @dchiu911, @ramnathv, @aedobbyn, @Bio7, @tonytonov, @samhinshaw, @fny,
@@ -693,35 +783,35 @@ This is a maintenance release without any breaking API changes.
 
 ## Major & dependency related changes
 
-* Removed implicit `dplyr` dependency via `purrr:::map_dfr()` (thanks
-  @jimhester, #324).
+-   Removed implicit `dplyr` dependency via `purrr:::map_dfr()` (thanks
+    @jimhester, #324).
 
-* Added required minimal version dependency for purr (`>= 0.2.3`) (#338).
+-   Added required minimal version dependency for purr (`>= 0.2.3`) (#338).
 
-* We rely on the tibble package which was optimized for speed in `v1.4.2` so
-  styler should run ~2x as fast
-  [(#348)](https://github.com/tidyverse/tibble/pull/348). For that reason,
-  styler now depends on `tibble >= 1.4.2`.
+-   We rely on the tibble package which was optimized for speed in `v1.4.2` so
+    styler should run \~2x as fast
+    [(#348)](https://github.com/tidyverse/tibble/pull/348). For that reason,
+    styler now depends on `tibble >= 1.4.2`.
 
-* In the dependency `enc`, a bug was fixed that removed/changed non-ASCII
-  characters. Hence, styler now depends on `enc >= 0.2` (#348).
+-   In the dependency `enc`, a bug was fixed that removed/changed non-ASCII
+    characters. Hence, styler now depends on `enc >= 0.2` (#348).
 
 ## Minor changes
 
-* We're now recognizing and respecting more DSLs used in R comments: rplumber
-  (`#*`, #306), shebang `#/!` (#345), knitr chunk headers for spinning (`#+` /
-  `#-`, #362).
+-   We're now recognizing and respecting more DSLs used in R comments: rplumber
+    (`#*`, #306), shebang `#/!` (#345), knitr chunk headers for spinning (`#+`
+    / `#-`, #362).
 
-* Named arguments can stay on the first line if call is multi-line (#318).
+-   Named arguments can stay on the first line if call is multi-line (#318).
 
-* No space anymore with `tidyverse_style()` after `!!` since with `rlang 0.2`,
-  `!!` now binds tighter (#322), spacing around `~` (#316), no space anymore
-  around `^` (#308).
+-   No space anymore with `tidyverse_style()` after `!!` since with
+    `rlang 0.2`, `!!` now binds tighter (#322), spacing around `~` (#316), no
+    space anymore around `^` (#308).
 
-* Code chunks in Rmd documents that don't use the R engine are no longer
-  formatted (#313).
+-   Code chunks in Rmd documents that don't use the R engine are no longer
+    formatted (#313).
 
-* Various bug fixes and edge case improvements.
+-   Various bug fixes and edge case improvements.
 
 Thanks to all contributors for patches, issues and the like: @devSJR, @klrmlr,
 @yutannihilation, @samhinshaw, @martin-mfg, @jjramsey, @RMHogervorst, @wlandau,
@@ -732,69 +822,68 @@ Thanks to all contributors for patches, issues and the like: @devSJR, @klrmlr,
 Initial release.
 
 ## stylers
-These are functions used to style code. They style a directory, a whole package,
-a file or a string.
-```
-style_dir(path = ".", 
-  ..., style = tidyverse_style, transformers = style(...), 
-  filetype = "R", recursive = TRUE, exclude_files = NULL
-)
 
-style_pkg(pkg = ".", 
-  ..., style = tidyverse_style, transformers = style(...), filetype = "R", 
-  exclude_files = "R/RcppExports.R"
-)
+These are functions used to style code. They style a directory, a whole
+package, a file or a string.
+
+    style_dir(path = ".", 
+      ..., style = tidyverse_style, transformers = style(...), 
+      filetype = "R", recursive = TRUE, exclude_files = NULL
+    )
+
+    style_pkg(pkg = ".", 
+      ..., style = tidyverse_style, transformers = style(...), filetype = "R", 
+      exclude_files = "R/RcppExports.R"
+    )
 
 
-style_file(path, 
-  ..., style = tidyverse_style, transformers = style(...)
-)
+    style_file(path, 
+      ..., style = tidyverse_style, transformers = style(...)
+    )
 
-style_text(text, ..., style = tidyverse_style, transformers = style(...))
-```
+    style_text(text, ..., style = tidyverse_style, transformers = style(...))
 
 ## style guides
+
 These functions are the style guides implemented.
-```
-tidyverse_style(
-  scope = "tokens", 
-  strict = TRUE, 
-  indent_by = 2, 
-  start_comments_with_one_space = FALSE, 
-  reindention = tidyverse_reindention(), 
-  math_token_spacing = tidyverse_math_token_spacing()
-)
-tidyverse_reindention()
-tidyverse_math_token_spacing())
-```
+
+    tidyverse_style(
+      scope = "tokens", 
+      strict = TRUE, 
+      indent_by = 2, 
+      start_comments_with_one_space = FALSE, 
+      reindention = tidyverse_reindention(), 
+      math_token_spacing = tidyverse_math_token_spacing()
+    )
+    tidyverse_reindention()
+    tidyverse_math_token_spacing())
 
 ## style guide creators
+
 This function is used to create a style guide.
-```
-create_style_guide(
-  initialize = default_style_guide_attributes, 
-  line_break = NULL, 
-  space = NULL, 
-  token = NULL, 
-  indention = NULL, 
-  use_raw_indention = FALSE, 
-  reindention = tidyverse_reindention()
-)
-```
+
+    create_style_guide(
+      initialize = default_style_guide_attributes, 
+      line_break = NULL, 
+      space = NULL, 
+      token = NULL, 
+      indention = NULL, 
+      use_raw_indention = FALSE, 
+      reindention = tidyverse_reindention()
+    )
 
 ## Helpers
+
 These are helper functions used to specify the style guides in use.
 
-```
-specify_math_token_spacing(
-  zero = NULL, 
-  one = c("'+'", "'-'", "'*'", "'/'", "'^'")
-)
+    specify_math_token_spacing(
+      zero = NULL, 
+      one = c("'+'", "'-'", "'*'", "'/'", "'^'")
+    )
 
-specify_reindention(
-  regex_pattern = NULL, 
-  indention = 0, 
-  comments_only = TRUE
-)
-initialize_default_attributes(pd_flat)
-```
+    specify_reindention(
+      regex_pattern = NULL, 
+      indention = 0, 
+      comments_only = TRUE
+    )
+    initialize_default_attributes(pd_flat)

--- a/README.Rmd
+++ b/README.Rmd
@@ -2,6 +2,9 @@
 output:
   github_document:
     html_preview: true
+editor_options: 
+  markdown: 
+    wrap: 79
 ---
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
@@ -17,29 +20,33 @@ knitr::opts_chunk$set(
 # styler
 
 <!-- badges: start -->
-[![R build status](https://github.com/r-lib/styler/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/styler/actions)
-[![Life cycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)
-[![codecov test coverage](https://app.codecov.io/gh/r-lib/styler/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/styler)
-[![CRAN Status](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
+
+[![R build
+status](https://github.com/r-lib/styler/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/styler/actions)
+[![Life cycle:
+stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)
+[![codecov test
+coverage](https://app.codecov.io/gh/r-lib/styler/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/styler)
+[![CRAN
+Status](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
+
 <!-- badges: end -->
 
-# Overview 
+# Overview
 
-styler formats your code according to the 
-[tidyverse style guide](https://style.tidyverse.org) (or your custom style guide)
-so you can direct your attention to the content of your code. It helps to 
-keep the coding style consistent across projects and facilitate collaboration. 
-You can access styler through 
+styler formats your code according to the [tidyverse style
+guide](https://style.tidyverse.org) (or your custom style guide) so you can
+direct your attention to the content of your code. It helps to keep the coding
+style consistent across projects and facilitate collaboration. You can access
+styler through
 
-* the RStudio Addin as demonstrated below
-* R functions like `style_pkg()`, `style_file()` or `style_text()`
-* various other tools described in `vignette("third-party-integrations")`
-
+-   the RStudio Addin as demonstrated below
+-   R functions like `style_pkg()`, `style_file()` or `style_text()`
+-   various other tools described in `vignette("third-party-integrations")`
 
 ```{r, out.width = "650px", echo = FALSE}
 knitr::include_graphics("https://raw.githubusercontent.com/lorenzwalthert/some_raw_data/master/styler_0.1.gif")
 ```
-
 
 ## Installation
 
@@ -60,6 +67,6 @@ remotes::install_github("r-lib/styler")
 
 The following online docs are available:
 
-- [latest CRAN release](https://styler.r-lib.org).
+-   [latest CRAN release](https://styler.r-lib.org).
 
-- [GitHub development version](https://styler.r-lib.org/dev/).
+-   [GitHub development version](https://styler.r-lib.org/dev/).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://
 coverage](https://app.codecov.io/gh/r-lib/styler/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/styler)
 [![CRAN
 Status](https://www.r-pkg.org/badges/version/styler)](https://cran.r-project.org/package=styler)
+
 <!-- badges: end -->
 
 # Overview

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,49 +1,49 @@
+---
+editor_options: 
+  markdown: 
+    wrap: 79
+---
+
 This release does not check for a specific error message from `parse()` anymore
-when the input involves unparsable use of `_`. The release was requested by Luke
-Tierney.
+when the input involves unparsable use of `_`. The release was requested by
+Luke Tierney.
 
 ## Test environments
 
-
-* ubuntu 18.04 (on GitHub Actions): R devel, R 4.1.2, R 4.0.5, R 3.6, R 3.5, R 3.4
-* Windows Server 10 (on GitHub Actions): R 3.6, R 4.0.5
-* win-builder: R devel
+-   ubuntu 18.04 (on GitHub Actions): R devel, R 4.1.2, R 4.0.5, R 3.6, R 3.5,
+    R 3.4
+-   Windows Server 10 (on GitHub Actions): R 3.6, R 4.0.5
+-   win-builder: R devel
 
 ## R CMD check results
 
-0 ERRORS | 0 WARNINGS | 1 NOTES
+0 ERRORS \| 0 WARNINGS \| 1 NOTES
 
-The note was generated on winbuilder when incoming checks were enabled only and 
-contained many blocks like this: 
+The note was generated on winbuilder when incoming checks were enabled only and
+contained many blocks like this:
 
-```
-Found the following (possibly) invalid URLs:
-  URL: https://github.com/ropensci/drake
-    From: inst/doc/third-party-integrations.html
-          NEWS.md
-    Status: 429
-    Message: Too Many Requests
-```    
+    Found the following (possibly) invalid URLs:
+      URL: https://github.com/ropensci/drake
+        From: inst/doc/third-party-integrations.html
+              NEWS.md
+        Status: 429
+        Message: Too Many Requests
 
 It seems my package contains many URLs to GitHub and their rate limit prevents
-the checking of all of them. I confirm that all URLs in my
-package are compliant with the requirements of CRAN.
+the checking of all of them. I confirm that all URLs in my package are
+compliant with the requirements of CRAN.
 
 ## Downstream Dependencies
 
-I also ran R CMD check on all downstream dependencies of styler using the 
-revdepcheck package. The 
-downstream dependencies are: 
+I also ran R CMD check on all downstream dependencies of styler using the
+revdepcheck package. The downstream dependencies are:
 
-* Reverse imports: biocthis, boomer, exampletestr, flow, iNZightTools, 
-  languageserver, questionr, shinymeta, shinyobjects, ShinyQuickStarter, 
-  systemPipeShiny, tidypaleo.
-	
-  	
-* Reverse suggests: 	admiral, autothresholdr, crunch, datastructures, drake, 
-  epigraphdb, ghclass, knitr, multiverse, nph, precommit, reprex, shiny.react,
-  shinydashboardPlus, shinyMonacoEditor, upsetjs, usethis.
+-   Reverse imports: biocthis, boomer, exampletestr, flow, iNZightTools,
+    languageserver, questionr, shinymeta, shinyobjects, ShinyQuickStarter,
+    systemPipeShiny, tidypaleo.
 
+-   Reverse suggests: admiral, autothresholdr, crunch, datastructures, drake,
+    epigraphdb, ghclass, knitr, multiverse, nph, precommit, reprex,
+    shiny.react, shinydashboardPlus, shinyMonacoEditor, upsetjs, usethis.
 
-All of them finished R CMD CHECK with zero (0) ERRORS, WARNINGS and 
-NOTES.
+All of them finished R CMD CHECK with zero (0) ERRORS, WARNINGS and NOTES.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -215,6 +215,7 @@ sprintf
 stackoverflow
 StackOverflow
 startsWith
+staticimports
 STR
 styler
 stylerignore
@@ -262,6 +263,7 @@ VignetteBuilder
 Visit'em
 walthert
 Walthert
+wch
 winbuilder
 withr
 writeLines

--- a/vignettes/caching.Rmd
+++ b/vignettes/caching.Rmd
@@ -18,29 +18,13 @@ knitr::opts_chunk$set(
 library(styler)
 ```
 
-This is a developer vignette to explain how caching works and what we learned on
-the way. To use the caching feature, please have a look at the README.
+This is a developer vignette to explain how caching works and what we learned on the way. To use the caching feature, please have a look at the README.
 
 The main caching features were implemented in the following two pull requests:
 
-- #538: Implemented simple caching and utilities for managing caches. Input text
-  is styled as a whole and added to the cache afterwards. This makes most sense
-  given that the very same expression will probably never be passed to styler,
-  unless it is already compliant with the style guide. Apart from the
-  (negligible) innode, caching text has a memory cost of 0. Speed boosts only
-  result if the whole text passed to styler is compliant to the style guide in
-  use. Changing one line in a file with hundreds of lines means each line will
-  be styled again. This is a major drawback and makes the cache only useful for
-  a use with a pre-commit framework (the initial motivation) or when functions
-  like `style_pkg()` are run often and most files were not changed.
+-   #538: Implemented simple caching and utilities for managing caches. Input text is styled as a whole and added to the cache afterwards. This makes most sense given that the very same expression will probably never be passed to styler, unless it is already compliant with the style guide. Apart from the (negligible) innode, caching text has a memory cost of 0. Speed boosts only result if the whole text passed to styler is compliant to the style guide in use. Changing one line in a file with hundreds of lines means each line will be styled again. This is a major drawback and makes the cache only useful for a use with a pre-commit framework (the initial motivation) or when functions like `style_pkg()` are run often and most files were not changed.
 
-- #578: Adds a second layer of caching by caching top-level expressions
-  individually. This will bring speed boosts to the situation where very little
-  is changed but there are many top-level expressions. Hence, changing one line
-  in a big file will invalidate the cache for the expression the line is part
-  of, i.e. when changing `x <- 2` to `x = 2` below, styler will have to restyle
-  the function definition, but not `another(call)` and all other expressions
-  that were not changed.
+-   #578: Adds a second layer of caching by caching top-level expressions individually. This will bring speed boosts to the situation where very little is changed but there are many top-level expressions. Hence, changing one line in a big file will invalidate the cache for the expression the line is part of, i.e. when changing `x <- 2` to `x = 2` below, styler will have to restyle the function definition, but not `another(call)` and all other expressions that were not changed.
 
 ```{r, eval = FALSE}
 function() {
@@ -51,59 +35,18 @@ function() {
 another(call)
 ```
 
-While #538 also required a lot of thought, this is not necessarily visible in
-the diff. The main challenge was to figure out how the caching should work
-conceptually and where we best insert the functionality as well as how to make
-caching work for edge cases like trailing blank lines etc. For details on the
-conceptual side and requirements, see #538.
+While #538 also required a lot of thought, this is not necessarily visible in the diff. The main challenge was to figure out how the caching should work conceptually and where we best insert the functionality as well as how to make caching work for edge cases like trailing blank lines etc. For details on the conceptual side and requirements, see #538.
 
-In comparison, the diff in #578 is much larger. We can walk through the main
-changes introduced here:
+In comparison, the diff in #578 is much larger. We can walk through the main changes introduced here:
 
-- Each nest gained a column *is_cached* to indicate if an expression is cached.
-  It's only ever set for the top-level nest, but set to `NA` for all other
-  nests. Also, comments are not cached because they are essentially top level
-  terminals which are very cheap to style (also because hardly any rule concerns
-  them) and because each comment is a top-level expression, simply styling them
-  is cheaper than checking for each of them if it is in the cache.
+-   Each nest gained a column *is_cached* to indicate if an expression is cached. It's only ever set for the top-level nest, but set to `NA` for all other nests. Also, comments are not cached because they are essentially top level terminals which are very cheap to style (also because hardly any rule concerns them) and because each comment is a top-level expression, simply styling them is cheaper than checking for each of them if it is in the cache.
 
-- Each nest also gained a column *block* to denote the block to which it belongs
-  for styling. Running each top-level expression through
-  `parse_transform_serialize_r()` separately is relatively expensive. We prefer
-  to put multiple top-level expressions into a block and process the block. This
-  is done with `parse_transform_serialize_r_block()`. Note that before we
-  implemented this PR, all top-level expressions were sent through
-  `parse_transform_serialize_r()` as one block. Leaving out some exceptions in
-  this explanation, we always put uncached top-level expressions in a block and
-  cached top-level expressions into a block and then style the uncached ones.
+-   Each nest also gained a column *block* to denote the block to which it belongs for styling. Running each top-level expression through `parse_transform_serialize_r()` separately is relatively expensive. We prefer to put multiple top-level expressions into a block and process the block. This is done with `parse_transform_serialize_r_block()`. Note that before we implemented this PR, all top-level expressions were sent through `parse_transform_serialize_r()` as one block. Leaving out some exceptions in this explanation, we always put uncached top-level expressions in a block and cached top-level expressions into a block and then style the uncached ones.
 
-- Apart from the actual styling, a very costly part of formatting code with
-  styler is to compute the nested parse data with `compute_parse_data_nested()`.
-  When caching top-level expressions, it is evident that building up the nested
-  structure for cached code is unnecessary because we don't actually style it,
-  but simply return `text`. For this reason, we introduce the concept of a
-  shallow nest. It can only occur at the top level. For the top-level
-  expressions we know that they are cached, we remove all children before
-  building up the nested parse table and let them act as `terminals` and will
-  later simply return their `text`. Hence, in the nested parse table, no cached
-  expressions have children.
+-   Apart from the actual styling, a very costly part of formatting code with styler is to compute the nested parse data with `compute_parse_data_nested()`. When caching top-level expressions, it is evident that building up the nested structure for cached code is unnecessary because we don't actually style it, but simply return `text`. For this reason, we introduce the concept of a shallow nest. It can only occur at the top level. For the top-level expressions we know that they are cached, we remove all children before building up the nested parse table and let them act as `terminals` and will later simply return their `text`. Hence, in the nested parse table, no cached expressions have children.
 
-- Because we now style blocks of expressions and we want to preserve the line
-  breaks between them, we need to keep track of all blank lines between
-  expressions, which was not necessary previously because all expressions were
-  in a block and the blank lines separating them were stored in `newlines` and
-  `lag_newlines` except for all blank lines before the first expression.
+-   Because we now style blocks of expressions and we want to preserve the line breaks between them, we need to keep track of all blank lines between expressions, which was not necessary previously because all expressions were in a block and the blank lines separating them were stored in `newlines` and `lag_newlines` except for all blank lines before the first expression.
 
-- Because we wanted to cache by expression, but process by block of expression,
-  we needed to decompose the block into individual expressions and add them to
-  the cache once we obtained the final text. We could probably also have added
-  expressions to the cache before we put the text together, but the problem is
-  that at some point we turn the nested structure into a flat structure and as
-  this must happen with a `post_visit()` approach, we'd have to implement a
-  complicated routine to check if we are now about to put together all top-level
-  expressions and then if yes write them to the cache. A simple (but maybe not
-  so elegant) parsing of the output as implemented in `cache_by_expression()`
-  seemed reasonable in terms of limiting complexity and keeping efficiency.
+-   Because we wanted to cache by expression, but process by block of expression, we needed to decompose the block into individual expressions and add them to the cache once we obtained the final text. We could probably also have added expressions to the cache before we put the text together, but the problem is that at some point we turn the nested structure into a flat structure and as this must happen with a `post_visit()` approach, we'd have to implement a complicated routine to check if we are now about to put together all top-level expressions and then if yes write them to the cache. A simple (but maybe not so elegant) parsing of the output as implemented in `cache_by_expression()` seemed reasonable in terms of limiting complexity and keeping efficiency.
 
-For more detailed explanation and documentation, please consult the help files
-of the internals.
+For more detailed explanation and documentation, please consult the help files of the internals.

--- a/vignettes/customizing_styler.Rmd
+++ b/vignettes/customizing_styler.Rmd
@@ -7,46 +7,19 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-This vignette provides a high-level overview of how styler works and how you can
-define your own style guide and format code according to it. If you simply want
-to customize the tidyverse style guide to your needs, check out 
-`vignette("styler")`, to remove some rules, have a look at 
-`vignette("remove_rules")`. How to distribute a custom style guide is described
-in `vignette("distribute_custom_style_guides")`.
+This vignette provides a high-level overview of how styler works and how you can define your own style guide and format code according to it. If you simply want to customize the tidyverse style guide to your needs, check out `vignette("styler")`, to remove some rules, have a look at `vignette("remove_rules")`. How to distribute a custom style guide is described in `vignette("distribute_custom_style_guides")`.
 
 # How styler works
 
 There are three major steps that styler performs in order to style code:
 
-1. Create an abstract syntax tree (AST) from `utils::getParseData()` that
-   contains positional information for every token. We call this a nested parse
-   table. You can learn more about how exactly this is done in the vignettes
-   "Data Structures" and "Manipulating the nested parse table".
+1.  Create an abstract syntax tree (AST) from `utils::getParseData()` that contains positional information for every token. We call this a nested parse table. You can learn more about how exactly this is done in the vignettes "Data Structures" and "Manipulating the nested parse table".
 
-2. Apply transformer functions at each level of the nested parse table. We use a
-   visitor approach, i.e. a function that takes functions as arguments and
-   applies them to every level of nesting. You can find out more about it on the
-   help file for `visit()`. Note that the function is not exported by styler.
-   The visitor will take care of applying the functions on every level of
-   nesting - and we can supply transformer functions that operate on one level
-   of nesting. In the sequel, we use the term *nest* to refer to such a parse
-   table at one level of nesting. A *nest* always represents a complete
-   expression. Before we apply the transformers, we have to initialize two
-   columns `lag_newlines` and `spaces`, which contain the number of line breaks
-   before the token and the number of spaces after the token. These will be the
-   columns that most of our transformer functions will modify.
+2.  Apply transformer functions at each level of the nested parse table. We use a visitor approach, i.e. a function that takes functions as arguments and applies them to every level of nesting. You can find out more about it on the help file for `visit()`. Note that the function is not exported by styler. The visitor will take care of applying the functions on every level of nesting - and we can supply transformer functions that operate on one level of nesting. In the sequel, we use the term *nest* to refer to such a parse table at one level of nesting. A *nest* always represents a complete expression. Before we apply the transformers, we have to initialize two columns `lag_newlines` and `spaces`, which contain the number of line breaks before the token and the number of spaces after the token. These will be the columns that most of our transformer functions will modify.
 
-3. Serialize the nested parse table, that is, extract the terminal tokens from
-   the nested parse table and add spaces and line breaks between them as
-   specified in the nested parse table.
+3.  Serialize the nested parse table, that is, extract the terminal tokens from the nested parse table and add spaces and line breaks between them as specified in the nested parse table.
 
-The `transformers` argument is, apart from the code to style, the key argument
-of functions such as `style_text()` and friends. By default, it is created via
-the `style` argument. The transformers are a named list of transformer functions
-and other arguments passed to styler. To use the default style guide of styler
-([the tidyverse style guide](https://style.tidyverse.org/)), call
-`tidyverse_style()` to get the list of the transformer functions. Let's quickly
-look at what those are.
+The `transformers` argument is, apart from the code to style, the key argument of functions such as `style_text()` and friends. By default, it is created via the `style` argument. The transformers are a named list of transformer functions and other arguments passed to styler. To use the default style guide of styler ([the tidyverse style guide](https://style.tidyverse.org/)), call `tidyverse_style()` to get the list of the transformer functions. Let's quickly look at what those are.
 
 ```{r, message = FALSE}
 library("styler")
@@ -56,23 +29,13 @@ names(tidyverse_style())
 str(tidyverse_style(), give.attr = FALSE, list.len = 3)
 ```
 
-We note that there are different types of transformer functions. `initialize`
-initializes some variables in the nested parse table (so it is not actually a
-transformer), and the other elements modify either spacing, line breaks or
-tokens. `use_raw_indention` is not a function, it is just an option. All
-transformer functions have a similar structure. Let's take a look at one:
+We note that there are different types of transformer functions. `initialize` initializes some variables in the nested parse table (so it is not actually a transformer), and the other elements modify either spacing, line breaks or tokens. `use_raw_indention` is not a function, it is just an option. All transformer functions have a similar structure. Let's take a look at one:
 
 ```{r}
 tidyverse_style()$space$remove_space_after_opening_paren
 ```
 
-As the name says, this function removes spaces after the opening parenthesis.
-But how? Its input is a *nest*. Since the visitor will go through all levels of
-nesting, we just need a function that can be applied to a *nest*, that is, to a
-parse table at one level of nesting. We can compute the nested parse table and
-look at one of the levels of nesting that is interesting for us (more on the
-data structure in the vignettes "Data structures" and "Manipulating the parse
-table"):
+As the name says, this function removes spaces after the opening parenthesis. But how? Its input is a *nest*. Since the visitor will go through all levels of nesting, we just need a function that can be applied to a *nest*, that is, to a parse table at one level of nesting. We can compute the nested parse table and look at one of the levels of nesting that is interesting for us (more on the data structure in the vignettes "Data structures" and "Manipulating the parse table"):
 
 ```{r}
 string_to_format <- "call( 3)"
@@ -82,32 +45,16 @@ pd$child[[1]] %>%
   select(token, terminal, text, newlines, spaces)
 ```
 
-`default_style_guide_attributes()` is called to initialize some variables, it
-does not actually transform the parse table.
+`default_style_guide_attributes()` is called to initialize some variables, it does not actually transform the parse table.
 
-All the function `remove_space_after_opening_paren()` now does is to look for
-the opening bracket and set the column `spaces` of the token to zero. Note that
-it is very important to check whether there is also a line break following after
-that token. If so, `spaces` should not be touched because of the way `spaces`
-and `newlines` are defined. `spaces` are the number of spaces after a token and
-`newlines`. Hence, if a line break follows, spaces are not EOL spaces, but
-rather the spaces directly before the next token. If there was a line break
-after the token and the rule did not check for that, indention for the token
-following `(` would be removed. This would be unwanted for example if
-`use_raw_indention` is set to `TRUE` (which means indention should not be
-touched). If we apply the rule to our parse table, we can see that the column
-`spaces` changes and is now zero for all tokens:
+All the function `remove_space_after_opening_paren()` now does is to look for the opening bracket and set the column `spaces` of the token to zero. Note that it is very important to check whether there is also a line break following after that token. If so, `spaces` should not be touched because of the way `spaces` and `newlines` are defined. `spaces` are the number of spaces after a token and `newlines`. Hence, if a line break follows, spaces are not EOL spaces, but rather the spaces directly before the next token. If there was a line break after the token and the rule did not check for that, indention for the token following `(` would be removed. This would be unwanted for example if `use_raw_indention` is set to `TRUE` (which means indention should not be touched). If we apply the rule to our parse table, we can see that the column `spaces` changes and is now zero for all tokens:
 
 ```{r}
 styler:::remove_space_after_opening_paren(pd$child[[1]]) %>%
   select(token, terminal, text, newlines, spaces)
 ```
 
-All top-level styling functions have a `style` argument (which defaults to
-`tidyverse_style`). If you check out the help file, you can see that the
-argument `style` is only used to create the default `transformers` argument,
-which defaults to `style(...)`. This allows for the styling options to be set
-without having to specify them inside the function passed to `transformers`.
+All top-level styling functions have a `style` argument (which defaults to `tidyverse_style`). If you check out the help file, you can see that the argument `style` is only used to create the default `transformers` argument, which defaults to `style(...)`. This allows for the styling options to be set without having to specify them inside the function passed to `transformers`.
 
 Let's clarify this with an example. The following yields the same result:
 
@@ -119,12 +66,7 @@ all.equal(
 )
 ```
 
-Now let's do the whole styling of a string with just this one transformer
-introduced above. We do this by first creating a style guide with the designated
-wrapper function `create_style_guide()`. It takes transformer functions as input
-and returns them in a named list that meets the formal requirements for styling
-functions. We also set a name and version of the style guide according to the
-convention outlined in `create_style_guide()`.
+Now let's do the whole styling of a string with just this one transformer introduced above. We do this by first creating a style guide with the designated wrapper function `create_style_guide()`. It takes transformer functions as input and returns them in a named list that meets the formal requirements for styling functions. We also set a name and version of the style guide according to the convention outlined in `create_style_guide()`.
 
 ```{r}
 space_after_opening_style <- function(are_you_sure) {
@@ -137,12 +79,7 @@ space_after_opening_style <- function(are_you_sure) {
 }
 ```
 
-Make sure to also disable caching during development with `cache_deactivate()`
-because styling the same text with a different style guide that has the same
-version and name will fool the cache invalidation in the case your style guide
-has transformer functions with different function bodies. Make sure to increment
-the version number of your style guide with every release. It should correspond
-to the version of the package from which you export your style guide.
+Make sure to also disable caching during development with `cache_deactivate()` because styling the same text with a different style guide that has the same version and name will fool the cache invalidation in the case your style guide has transformer functions with different function bodies. Make sure to increment the version number of your style guide with every release. It should correspond to the version of the package from which you export your style guide.
 
 We can not try the style guide:
 
@@ -150,76 +87,45 @@ We can not try the style guide:
 style_text("call( 1,1)", style = space_after_opening_style, are_you_sure = TRUE)  
 ```
 
-Note that the return value of your `style` function may not contain `NULL`
-elements.
+Note that the return value of your `style` function may not contain `NULL` elements.
 
-I hope you have acquired a basic understanding of how styler transforms code.
-You can provide your own transformer functions and use `create_style_guide()` to
-create customized code styling. If you do so, there are a few more things you
-should be aware of, which are described in the next section.
+I hope you have acquired a basic understanding of how styler transforms code. You can provide your own transformer functions and use `create_style_guide()` to create customized code styling. If you do so, there are a few more things you should be aware of, which are described in the next section.
 
 # Implementation details
 
-For both spaces and line break information in the nested parse table, we use
-four attributes in total: `newlines`, `lag_newlines`, `spaces`, and
-`lag_spaces`. `lag_spaces` is created from `spaces` only just before the parse
-table is serialized, so it is not relevant for manipulating the parse table as
-described above. These columns are to some degree redundant, but with just lag
-or lead, we would lose information on the first or the last element
-respectively, so we need both.
+For both spaces and line break information in the nested parse table, we use four attributes in total: `newlines`, `lag_newlines`, `spaces`, and `lag_spaces`. `lag_spaces` is created from `spaces` only just before the parse table is serialized, so it is not relevant for manipulating the parse table as described above. These columns are to some degree redundant, but with just lag or lead, we would lose information on the first or the last element respectively, so we need both.
 
-The sequence in which styler applies rules on each level of nesting is given in
-the list below:
+The sequence in which styler applies rules on each level of nesting is given in the list below:
 
-* call `default_style_guide_attributes()` to initialize some variables.
+-   call `default_style_guide_attributes()` to initialize some variables.
 
-* modify the line breaks (modifying `lag_newlines` only based on `token`,
-  `token_before`, `token_after` and `text`).
+-   modify the line breaks (modifying `lag_newlines` only based on `token`, `token_before`, `token_after` and `text`).
 
-* modify the spaces (modifying `spaces` only based on `lag_newlines`,
-  `newlines`, `multi_line`, `token`, `token_before`, `token_after` and `text`).
+-   modify the spaces (modifying `spaces` only based on `lag_newlines`, `newlines`, `multi_line`, `token`, `token_before`, `token_after` and `text`).
 
-* modify the tokens (based on `newlines` `lag_newlines`, `spaces` `multi_line`,
-  `token`, `token_before`, `token_after` and `text`).
+-   modify the tokens (based on `newlines` `lag_newlines`, `spaces` `multi_line`, `token`, `token_before`, `token_after` and `text`).
 
-* modify the indention by changing `indention_ref_id` (based on `newlines`
-  `lag_newlines`, `spaces` `multi_line`, `token`, `token_before`, `token_after`
-  and `text`).
+-   modify the indention by changing `indention_ref_id` (based on `newlines` `lag_newlines`, `spaces` `multi_line`, `token`, `token_before`, `token_after` and `text`).
 
-You can also look this up in the function that applies the transformers:
-`apply_transformers()`:
+You can also look this up in the function that applies the transformers: `apply_transformers()`:
 
 ```{r}
 styler:::apply_transformers
 ```
 
-This means that the order of the styling is clearly defined and it is for
-example not possible to modify line breaks based on spacing, because spacing
-will be set after line breaks are set. Do not rely on the column `col1`, `col2`,
-`line1` and `line2` in the parse table in any of your functions since these
-columns only reflect the position of tokens at the point of parsing,
+This means that the order of the styling is clearly defined and it is for example not possible to modify line breaks based on spacing, because spacing will be set after line breaks are set. Do not rely on the column `col1`, `col2`, `line1` and `line2` in the parse table in any of your functions since these columns only reflect the position of tokens at the point of parsing,
 
 i.e. they are not kept up to date throughout the process of styling.
 
-Also, as indicated above, work with `lag_newlines` only in your line break
-rules. For development purposes, you may also want to use the unexported
-function `test_collection()` to help you with testing your style guide. You can
-find more information in the help file for the function.
+Also, as indicated above, work with `lag_newlines` only in your line break rules. For development purposes, you may also want to use the unexported function `test_collection()` to help you with testing your style guide. You can find more information in the help file for the function.
 
-If you write functions that modify spaces, don't forget to make sure that you
-don't modify EOL spacing, since that is needed for `use_raw_indention`, as
-highlighted previously.
+If you write functions that modify spaces, don't forget to make sure that you don't modify EOL spacing, since that is needed for `use_raw_indention`, as highlighted previously.
 
-Finally, take note of the naming convention. All function names starting with
-`set-*` correspond to the `strict` option, that is, setting some value to an
-exact number. `add-*` is softer. For example, `add_spaces_around_op()`, only
-makes sure that there is at least one space around operators, but if the code to
-style contains multiple, the transformer will not change that.
+Finally, take note of the naming convention. All function names starting with `set-*` correspond to the `strict` option, that is, setting some value to an exact number. `add-*` is softer. For example, `add_spaces_around_op()`, only makes sure that there is at least one space around operators, but if the code to style contains multiple, the transformer will not change that.
 
 # Showcasing the development of a styling rule
 
-For illustrative purposes, we create a new style guide that has one rule only:
-Curly braces are always on a new line. So for example:
+For illustrative purposes, we create a new style guide that has one rule only: Curly braces are always on a new line. So for example:
 
 ```{r}
 add_one <- function(x) {
@@ -236,9 +142,7 @@ add_one <- function(x)
 }
 ```
 
-We first need to get familiar with the structure of the nested parse table. Note
-that the structure of the nested parse table is not affected by the position of
-line breaks and spaces. Let's first create the nested parse table.
+We first need to get familiar with the structure of the nested parse table. Note that the structure of the nested parse table is not affected by the position of line breaks and spaces. Let's first create the nested parse table.
 
 ```{r}
 code <- c("add_one <- function(x) { x + 1 }")
@@ -273,16 +177,13 @@ styler:::create_tree(code)
 pd <- styler:::compute_parse_data_nested(code)
 ```
 
-The token of interest here has id number 10. Let's navigate there. Since line
-break rules manipulate the lags *before* the token, we need to change
-`lag_newlines` at the token "'{'".
+The token of interest here has id number 10. Let's navigate there. Since line break rules manipulate the lags *before* the token, we need to change `lag_newlines` at the token "'{'".
 
 ```{r}
 pd$child[[1]]$child[[3]]$child[[5]]
 ```
 
-Remember what we said above: A transformer takes a flat parse table as input,
-updates it and returns it. So here it's actually simple:
+Remember what we said above: A transformer takes a flat parse table as input, updates it and returns it. So here it's actually simple:
 
 ```{r}
 set_line_break_before_curly_opening <- function(pd_flat) {
@@ -292,8 +193,7 @@ set_line_break_before_curly_opening <- function(pd_flat) {
 }
 ```
 
-Almost done. Now, the last thing we need to do is to use `create_style_guide()`
-to create our style guide consisting of that function.
+Almost done. Now, the last thing we need to do is to use `create_style_guide()` to create our style guide consisting of that function.
 
 ```{r}
 set_line_break_before_curly_opening_style <- function() {
@@ -311,8 +211,7 @@ Now you can style your string according to it.
 style_text(code, style = set_line_break_before_curly_opening_style)
 ```
 
-Note that when removing line breaks, always take care of comments, since you
-don't want:
+Note that when removing line breaks, always take care of comments, since you don't want:
 
 ```{r, eval = FALSE}
 a <- function() # comments should remain EOL
@@ -329,27 +228,14 @@ a <- function() # comments should remain EOL {
 }
 ```
 
-The easiest way of taking care of that is not applying the rule if there is a
-comment before the token of interest, which can be checked for within your
-transformer function. The transformer function from the tidyverse style that
-removes line breaks before the round closing bracket that comes after a curly
-brace looks as follows:
+The easiest way of taking care of that is not applying the rule if there is a comment before the token of interest, which can be checked for within your transformer function. The transformer function from the tidyverse style that removes line breaks before the round closing bracket that comes after a curly brace looks as follows:
 
 ```{r}
 styler:::remove_line_break_before_round_closing_after_curly
 ```
 
-With our example function `set_line_break_before_curly_opening()` we don't need
-to worry about that as we are only adding line breaks, but we don't remove
-them.
+With our example function `set_line_break_before_curly_opening()` we don't need to worry about that as we are only adding line breaks, but we don't remove them.
 
 # Cache invalidation
 
-Note that it if you re-distribute the style guide, it's your responsibility to
-set the version and the style guide name in `create_style_guide()` correctly. If
-you distribute a new version of your style guide and you don't increment the
-version number, it might have drastic consequences for your user: Under some
-circumstances (see `help("cache_make_key")`), your new style guide won't
-invalidate the cache although it should and applying your style guide to code
-that has previously been styled won't result in any change. There is currently 
-no mechanism in styler that prevents you from making this mistake.
+Note that it if you re-distribute the style guide, it's your responsibility to set the version and the style guide name in `create_style_guide()` correctly. If you distribute a new version of your style guide and you don't increment the version number, it might have drastic consequences for your user: Under some circumstances (see `help("cache_make_key")`), your new style guide won't invalidate the cache although it should and applying your style guide to code that has previously been styled won't result in any change. There is currently no mechanism in styler that prevents you from making this mistake.

--- a/vignettes/detect-alignment.Rmd
+++ b/vignettes/detect-alignment.Rmd
@@ -22,8 +22,7 @@ call(
 )
 ```
 
-Until styler 1.1.1.9002 (with `strict = TRUE`, e.g. as in
-`styler::style_file(..., strict = TRUE)`), this was formatted as follows:
+Until styler 1.1.1.9002 (with `strict = TRUE`, e.g. as in `styler::style_file(..., strict = TRUE)`), this was formatted as follows:
 
 ```{r}
 call(
@@ -32,20 +31,15 @@ call(
 )
 ```
 
-because no alignment detection was built in.^[With `strict = FALSE`, the spacing
-would have been kept, however, `strict = FALSE` has a number of other
-implications because it is in general less invasive. For example, it would not
-add braces and line breaks to "if (TRUE) return()".]
+because no alignment detection was built in.[^1]
 
-styler >= 1.1.1.9003 detects aforementioned alignment for function calls. This
-vignette describes how aligned code is defined in styler and gives some examples
-so users can format their aligned code to match the definition styler uses to
-ensure their code is not unintentionally reformatted.
+[^1]: With `strict = FALSE`, the spacing would have been kept, however, `strict = FALSE` has a number of other implications because it is in general less invasive. For example, it would not add braces and line breaks to "if (TRUE) return()".
+
+styler \>= 1.1.1.9003 detects aforementioned alignment for function calls. This vignette describes how aligned code is defined in styler and gives some examples so users can format their aligned code to match the definition styler uses to ensure their code is not unintentionally reformatted.
 
 ## Examples
 
-These typical examples match *styler*'s definition of alignment. Note the 
-spacing around operators and commas.
+These typical examples match *styler*'s definition of alignment. Note the spacing around operators and commas.
 
 ```{r}
 tibble::tribble(
@@ -75,12 +69,7 @@ purrr::map(x, fun, # arguments on same line as opening brace are not considered
 
 # Details
 
-An important definition used in the remainder is the one of a **column**. All
-arguments of a function call that have the same position but are placed on
-different lines form a column. The below call shows a call with two columns and
-two rows. Columns separate arguments of the function call, so the separator is
-the comma. The first row is named because all arguments are named, the second is
-unnamed:
+An important definition used in the remainder is the one of a **column**. All arguments of a function call that have the same position but are placed on different lines form a column. The below call shows a call with two columns and two rows. Columns separate arguments of the function call, so the separator is the comma. The first row is named because all arguments are named, the second is unnamed:
 
 ```{r}
 call(
@@ -90,13 +79,11 @@ call(
 )
 ```
 
-**For alignment detection, the first column is omitted if not all arguments 
-in that column are named**
+**For alignment detection, the first column is omitted if not all arguments in that column are named**
 
 ## Function calls
 
-Below, we try to explain in an intuitive way how your code should look like to
-be recognized as aligned.
+Below, we try to explain in an intuitive way how your code should look like to be recognized as aligned.
 
 Make commas match position vertically and align everything right before commas:
 
@@ -124,8 +111,7 @@ gell(
 )
 ```
 
-... or match position of `=` vertically and align everything after this operator
-left
+... or match position of `=` vertically and align everything after this operator left
 
 ```{r}
 # all arguments of first column named -> must left align values after `=`,
@@ -152,7 +138,6 @@ gell(
   31, fds = -1, gz = f / 3 + 1,
 )
 ```
-
 
 ... or match the start of the token after `,`
 

--- a/vignettes/distribute_custom_style_guides.Rmd
+++ b/vignettes/distribute_custom_style_guides.Rmd
@@ -14,79 +14,44 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignette describes how you can distribute your own style guide. It builds
-on `vignette("customizing_styler")` and assumes you understand how to create a 
-style guide with `create_style_guide()`.
+This vignette describes how you can distribute your own style guide. It builds on `vignette("customizing_styler")` and assumes you understand how to create a style guide with `create_style_guide()`.
 
 ## Reference implementations
 
-There are a few packages that implement a third-party style guide that are
-maintained by styler contributors:
+There are a few packages that implement a third-party style guide that are maintained by styler contributors:
 
-* [lorenzwalthert/styler.nocomments](https://github.com/lorenzwalthert/styler.nocomments)
-* [lorenzwalthert/semicoloner](https://github.com/lorenzwalthert/semicoloner)
-* [lorenzwalthert/oneliner](https://github.com/lorenzwalthert/oneliner)
-* [mlr-org/styler.mlr](https://github.com/mlr-org/styler.mlr)
+-   [lorenzwalthert/styler.nocomments](https://github.com/lorenzwalthert/styler.nocomments)
+-   [lorenzwalthert/semicoloner](https://github.com/lorenzwalthert/semicoloner)
+-   [lorenzwalthert/oneliner](https://github.com/lorenzwalthert/oneliner)
+-   [mlr-org/styler.mlr](https://github.com/mlr-org/styler.mlr)
 
 Other available style guides include:
 
-* [ropensci-review-tools/spaceout](https://github.com/ropensci-review-tools/spaceout)
-* [gadenbuie/grkstyle](https://github.com/gadenbuie/grkstyle)
+-   [ropensci-review-tools/spaceout](https://github.com/ropensci-review-tools/spaceout)
+-   [gadenbuie/grkstyle](https://github.com/gadenbuie/grkstyle)
 
-To start out, you can use the 
-[GitHub Template](https://github.com/lorenzwalthert/styler.yours) for 
-third-party style guides that has already the right directory structure and 
-patterns described below in place.
+To start out, you can use the [GitHub Template](https://github.com/lorenzwalthert/styler.yours) for third-party style guides that has already the right directory structure and patterns described below in place.
 
 You made one too? Please submit a PR to include it in the list.
 
 ## Design patterns
 
-The style guides mentioned above follow best practices and can serve as a good 
-and rather minimal example of how to implement your own style guide. Most 
-importantly, these two packages:
+The style guides mentioned above follow best practices and can serve as a good and rather minimal example of how to implement your own style guide. Most importantly, these two packages:
 
-* export all functions that {styler} exports, but the `style` argument set
-  to the custom style guide, plus custom style guides. 
-  The advantage of this is that you can use that namespace as a drop-in 
-  replacement for styler everywhere. In particular, if you want to use the 
-  tidyverse style guide, use `styler::style_pkg()`, if you want to use a 
-  third-party style guide, use the other namespace, e.g. `styler.mlr::style_pkg()`
-* depend on {styler} and use {styler} internals via `:::`.
-  These internals are subject to change without prior notice, which is why the 
-  packages also have unit tests. Also note that importing internals from another
-  package means your package can't be added to CRAN because packages calling 
-  private methods from other packages don't pass CRAN checks. The only way around this
-  would be to export some styler internals, e.g. via a {styler.infra} package, 
-  but that would be a lot of work on our side and therefore not currently on the
-  roadmap. Another alternative for 
-  developers might be to use https://github.com/wch/staticimports, which we have
-  not explored so far.
-* implement unit tests following {styler}'s testing convention with `*-in.R` and 
-  `*-out.R` files that are checked with `styler:::test_collection()`.
+-   export all functions that {styler} exports, but the `style` argument set to the custom style guide, plus custom style guides. The advantage of this is that you can use that namespace as a drop-in replacement for styler everywhere. In particular, if you want to use the tidyverse style guide, use `styler::style_pkg()`, if you want to use a third-party style guide, use the other namespace, e.g. `styler.mlr::style_pkg()`
+-   depend on {styler} and use {styler} internals via `:::`. These internals are subject to change without prior notice, which is why the packages also have unit tests. Also note that importing internals from another package means your package can't be added to CRAN because packages calling private methods from other packages don't pass CRAN checks. The only way around this would be to export some styler internals, e.g. via a {styler.infra} package, but that would be a lot of work on our side and therefore not currently on the roadmap. Another alternative for developers might be to use <https://github.com/wch/staticimports>, which we have not explored so far.
+-   implement unit tests following {styler}'s testing convention with `*-in.R` and `*-out.R` files that are checked with `styler:::test_collection()`.
 
+When creating a custom style guide and distribute it, we want to quickly recall important arguments for `create_style_guide()` from the docs:
 
-When creating a custom style guide and distribute it, we want to quickly recall 
-important arguments for `create_style_guide()` from the docs:
+-   `style_guide_name`, `style_guide_version` and `more_specs_style_guide`: These arguments are relevant for caching and make sure the user's cache is invalidated on releasing a new version. The documentation specifies how to set these arguments.
+-   `transformers_drop`: This argument can be created with `specify_transformers_drop()` to define conditions under which a transformer can be removed from the style guide without an effect on the result. This makes styler faster. For example, if you have a transformer that removes the token `;` and replaces it with a line break, it is only required if the code to style contains this token. Since this will hardly be the case for people who adhere to the tidyverse style guide, we formulate such a rule like this
 
-* `style_guide_name`, `style_guide_version` and `more_specs_style_guide`: 
-  These arguments are relevant for caching and make sure the user's cache is 
-  invalidated on releasing a new version. The documentation specifies how to 
-  set these arguments.
-* `transformers_drop`: This argument can be created with `specify_transformers_drop()`
-  to define conditions under which a transformer can be removed from the style 
-  guide without an effect on the result. This makes styler faster. For example, 
-  if you have a transformer that removes the token `;` and replaces it with a 
-  line break, it is only required if the code to style contains this token. 
-  Since this will hardly be the case for people who adhere to the tidyverse 
-  style guide, we formulate such a rule like this
-  
 ```{r}
 styler::specify_transformers_drop(
   spaces = list(style_space_around_tilde = "'~'"),
   tokens = list(resolve_semicolon = "';'")
 )
 ```
-  
-Where the name must correspond to the transformer function in question and the 
-value is the token that must be absent in order to drop the transformer.
+
+Where the name must correspond to the transformer function in question and the value is the token that must be absent in order to drop the transformer.

--- a/vignettes/introducing_styler.Rmd
+++ b/vignettes/introducing_styler.Rmd
@@ -7,9 +7,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-> This is an old vignette superseded by *Get started*. It might be outdated and 
-  is not yet deleted to avoid HTTP 404 errors until re-directs are implemented 
-  in pkgdown: https://github.com/r-lib/pkgdown/issues/1259
+> This is an old vignette superseded by *Get started*. It might be outdated and is not yet deleted to avoid HTTP 404 errors until re-directs are implemented in pkgdown: <https://github.com/r-lib/pkgdown/issues/1259>
 
 ```{r, echo = FALSE}
 knitr::opts_chunk$set(echo = TRUE, comment = "")
@@ -29,31 +27,26 @@ knitr::knit_engines$set(list(
 
 styler provides the following API to format code:
 
-* `style_file()` styles .R, .Rmd .Rnw and .Rprofile files.
+-   `style_file()` styles .R, .Rmd .Rnw and .Rprofile files.
 
-* `style_dir()` styles all .R and/or .Rmd files in a directory.
+-   `style_dir()` styles all .R and/or .Rmd files in a directory.
 
-* `style_pkg()` styles the source files of an R package.
+-   `style_pkg()` styles the source files of an R package.
 
-* RStudio Addins for styling the active file, styling the current package and
-  styling the highlighted selection, see `help("styler_addins")`.
+-   RStudio Addins for styling the active file, styling the current package and styling the highlighted selection, see `help("styler_addins")`.
 
-Beyond that, styler can be used through other tools documented in the
-`vignette("third-party-integrations")`.
+Beyond that, styler can be used through other tools documented in the `vignette("third-party-integrations")`.
 
 ### Passing arguments to the style guide
 
-styler separates the abstract definition of a style guide from the application
-of it. That's why you must supply a style guide via `transformers` when
-styling (in case you don't want to rely on the defaults):
+styler separates the abstract definition of a style guide from the application of it. That's why you must supply a style guide via `transformers` when styling (in case you don't want to rely on the defaults):
 
 ```{r}
 library(styler)
 style_text("a + b", transformers = tidyverse_style(scope = "indention"))
 ```
 
-The styler API was designed so that you can pass arguments to the style guide
-via the styling function (e.g. `style_file()`) to allow more concise syntax:
+The styler API was designed so that you can pass arguments to the style guide via the styling function (e.g. `style_file()`) to allow more concise syntax:
 
 ```{r, results = 'hide'}
 # equivalent
@@ -63,33 +56,27 @@ style_text("a + b", scope = "indention")
 
 The magic is possible thanks to `...`. See `style_text()` for details.
 
-# Invasiveness 
+# Invasiveness
 
-### `scope`: What to style? 
+### `scope`: What to style?
 
-This argument of `tidyverse_style()` determines the invasiveness of styling. The
-following levels for `scope` are available (in increasing order):
+This argument of `tidyverse_style()` determines the invasiveness of styling. The following levels for `scope` are available (in increasing order):
 
-* "none": Performs no transformation at all.
+-   "none": Performs no transformation at all.
 
-* "spaces": Manipulates spacing between token on the same line.
+-   "spaces": Manipulates spacing between token on the same line.
 
-* "indention": Manipulates the indention, i.e. number of spaces at the beginning
-  of each line.
+-   "indention": Manipulates the indention, i.e. number of spaces at the beginning of each line.
 
-* "line_breaks": Manipulates line breaks between tokens.
+-   "line_breaks": Manipulates line breaks between tokens.
 
-* "tokens": manipulates tokens.
+-   "tokens": manipulates tokens.
 
 There are two ways to specify the scope of styling.
 
-* As a string: In this case all less invasive scope levels are implied, e.g.
-  `"line_breaks"` includes `"indention"`, `"spaces"`. This is brief and what
-  most users need. This is supported in `styler >= 1.0.0`.
+-   As a string: In this case all less invasive scope levels are implied, e.g. `"line_breaks"` includes `"indention"`, `"spaces"`. This is brief and what most users need. This is supported in `styler >= 1.0.0`.
 
-* As vector of class `AsIs`: Each level has to be listed explicitly by wrapping
-  one ore more levels of the scope in `I()`. This offers more granular control
-  at the expense of more verbosity. This is supported in `styler > 1.3.2`.
+-   As vector of class `AsIs`: Each level has to be listed explicitly by wrapping one ore more levels of the scope in `I()`. This offers more granular control at the expense of more verbosity. This is supported in `styler > 1.3.2`.
 
 ```{r}
 # tokens and everything less invasive
@@ -99,16 +86,12 @@ style_text("a=2", scope = "tokens")
 style_text("a=2", scope = I(c("tokens", "indention")))
 ```
 
-As you can see from the output, the assignment operator `=` is replaced with
-`<-` in both cases, but spacing remained unchanged in the second example.
+As you can see from the output, the assignment operator `=` is replaced with `<-` in both cases, but spacing remained unchanged in the second example.
 
 ### How `strict` do you want styler to be?
 
-Another option that is helpful to determine the level of 'invasiveness' is
-`strict` (defaulting to `TRUE`). Some rules won't be applied so strictly with
-`strict = FALSE`, assuming you deliberately formatted things the way they are.
-Please see in `vignette("strict")`. For `styler >= 1.2` alignment in function
-calls is detected and preserved so you don't need `strict = FALSE`, e.g.
+Another option that is helpful to determine the level of 'invasiveness' is `strict` (defaulting to `TRUE`). Some rules won't be applied so strictly with `strict = FALSE`, assuming you deliberately formatted things the way they are. Please see in `vignette("strict")`. For `styler >= 1.2` alignment in function calls is detected and preserved so you don't need `strict = FALSE`, e.g.
+
 ```{r}
 style_text(
   "tibble::tibble(
@@ -123,9 +106,7 @@ The details are in `vignette("detect-alignment")`.
 
 # Ignoring certain lines
 
-You can tell styler to ignore some lines if you want to keep current formatting.
-You can mark whole blocks or inline expressions with `styler: on` and `styler:
-off`:
+You can tell styler to ignore some lines if you want to keep current formatting. You can mark whole blocks or inline expressions with `styler: on` and `styler: off`:
 
 ```{r}
 styler::style_text(
@@ -145,38 +126,24 @@ styler::style_text(
 "
 )
 ```
-You can also use custom markers as described in 
-`help("stylerignore", package = "styler")`. As described above and in
-`vignette("detect-alignment")`,
-some alignment is recognized and hence, *stylerignore* should not 
-be necessary in that context.
+
+You can also use custom markers as described in `help("stylerignore", package = "styler")`. As described above and in `vignette("detect-alignment")`, some alignment is recognized and hence, *stylerignore* should not be necessary in that context.
 
 # Caching
 
-styler is rather slow, so leveraging a cache for styled code brings big speedups
-in many situations. Starting with version `1.3.0`, you can benefit from it. For
-people using styler interactively (e.g. in RStudio), typing
-`styler::cache_info()` and then confirming the creation of a permanent cache is
-sufficient. Please refer to `help("caching")` for more information. The cache is
-by default dependent on the version of styler which means if you upgrade, the
-cache will be re-built. Also, the cache takes literally 0 disk space because
-only the hash of styled code is stored.
+styler is rather slow, so leveraging a cache for styled code brings big speedups in many situations. Starting with version `1.3.0`, you can benefit from it. For people using styler interactively (e.g. in RStudio), typing `styler::cache_info()` and then confirming the creation of a permanent cache is sufficient. Please refer to `help("caching")` for more information. The cache is by default dependent on the version of styler which means if you upgrade, the cache will be re-built. Also, the cache takes literally 0 disk space because only the hash of styled code is stored.
 
 # Dry mode
 
-As of version `1.3.2`, styler has a dry mode which avoids writing output to the
-file(s) you want to format. The following options are available:
+As of version `1.3.2`, styler has a dry mode which avoids writing output to the file(s) you want to format. The following options are available:
 
-- *off* (default): Write back to the file if applying styling changes the
-  input.
+-   *off* (default): Write back to the file if applying styling changes the input.
 
-- *on*: Applies styling and returns the results without writing changes (if any) back to the file(s).
+-   *on*: Applies styling and returns the results without writing changes (if any) back to the file(s).
 
-- *fail*: returns an error if the result of styling is not identical to the
-  input.
+-   *fail*: returns an error if the result of styling is not identical to the input.
 
-In any case, you can use the (invisible) return value of `style_file()` and
-friends to learn how files were changed (or would have changed):
+In any case, you can use the (invisible) return value of `style_file()` and friends to learn how files were changed (or would have changed):
 
 ```{r}
 out <- withr::with_tempfile(
@@ -203,9 +170,7 @@ This is enabled by default, you can turn it off with `include_roxygen_examples =
 1++1-1-1/2
 ```
 
-This is tidyverse style. However, styler offers very granular control for math
-token spacing. Assuming you like spacing around `+` and `-`, but not around `/`
-and `*` and `^`, do the following:
+This is tidyverse style. However, styler offers very granular control for math token spacing. Assuming you like spacing around `+` and `-`, but not around `/` and `*` and `^`, do the following:
 
 ```{r}
 style_text(
@@ -216,9 +181,7 @@ style_text(
 
 ### Custom indention
 
-If you, say, don't want comments starting with `###` to be indented and
-indention to be 4 instead of two spaces, you can formulate an unindention rule
-and set `indent_by` to 4:
+If you, say, don't want comments starting with `###` to be indented and indention to be 4 instead of two spaces, you can formulate an unindention rule and set `indent_by` to 4:
 
 ```{r}
 style_text(
@@ -236,7 +199,4 @@ style_text(
 
 ### Custom style guides
 
-These verse some (not all) configurations exposed in `style_file()` and friends
-as well as `tidyverse_style()`. If the above did not give you the flexibility
-you hoped for, your can create your own style guide and customize styler even
-further, as described in `vignette("customizing_styler")`.
+These verse some (not all) configurations exposed in `style_file()` and friends as well as `tidyverse_style()`. If the above did not give you the flexibility you hoped for, your can create your own style guide and customize styler even further, as described in `vignette("customizing_styler")`.

--- a/vignettes/performance_improvements.Rmd
+++ b/vignettes/performance_improvements.Rmd
@@ -7,97 +7,77 @@ vignette: >
   %\VignetteIndexEntry{Performance Improvements}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-
 ---
 
 We want to make styler faster.
 
-
-```
-library(styler)
-microbenchmark::microbenchmark(
-  base = style_file("tests/testthat/indention_multiple/overall-in.R"),
-  times = 2
-)
-#> Unit: seconds
-#>  expr      min       lq     mean   median       uq      max neval
-#>  base 4.131253 4.131253 4.172017 4.172017 4.212781 4.212781     2
-```
+    library(styler)
+    microbenchmark::microbenchmark(
+      base = style_file("tests/testthat/indention_multiple/overall-in.R"),
+      times = 2
+    )
+    #> Unit: seconds
+    #>  expr      min       lq     mean   median       uq      max neval
+    #>  base 4.131253 4.131253 4.172017 4.172017 4.212781 4.212781     2
 
 Replacing mutate statements.
 
-```
 
-microbenchmark::microbenchmark(
-  base = style_file("tests/testthat/indention_multiple/overall-in.R"),
-  times = 2
-)
-#> Unit: seconds
-#>  expr     min      lq     mean   median       uq      max neval
-#>  base 2.13616 2.13616 2.223659 2.223659 2.311158 2.311158     2
-```
+    microbenchmark::microbenchmark(
+      base = style_file("tests/testthat/indention_multiple/overall-in.R"),
+      times = 2
+    )
+    #> Unit: seconds
+    #>  expr     min      lq     mean   median       uq      max neval
+    #>  base 2.13616 2.13616 2.223659 2.223659 2.311158 2.311158     2
 
 Move `opening` argument out of needs indention.
 
-```
-microbenchmark::microbenchmark(
-  base = style_file("tests/testthat/indention_multiple/overall-in.R"),
-  times = 5
-)
+    microbenchmark::microbenchmark(
+      base = style_file("tests/testthat/indention_multiple/overall-in.R"),
+      times = 5
+    )
 
-#> Unit: seconds
-#>  expr     min       lq     mean   median       uq      max neval
-#>  base 2.18097 2.184721 2.225294 2.200893 2.241799 2.318089     5
-```
+    #> Unit: seconds
+    #>  expr     min       lq     mean   median       uq      max neval
+    #>  base 2.18097 2.184721 2.225294 2.200893 2.241799 2.318089     5
 
 Dropping unnecessary select statements and arrange stuff.
 
-```
-microbenchmark::microbenchmark(
-  base = style_file("tests/testthat/indention_multiple/overall-in.R"),
-  times = 5
-)
-#> Unit: seconds
-#>  expr      min       lq     mean   median       uq      max neval
-#>  base 2.109271 2.134377 2.147821 2.158567 2.165384 2.171505     5
-```
-
+    microbenchmark::microbenchmark(
+      base = style_file("tests/testthat/indention_multiple/overall-in.R"),
+      times = 5
+    )
+    #> Unit: seconds
+    #>  expr      min       lq     mean   median       uq      max neval
+    #>  base 2.109271 2.134377 2.147821 2.158567 2.165384 2.171505     5
 
 Some more stuff (early return, purr)
 
-```
-microbenchmark::microbenchmark(
-  base = style_file("tests/testthat/indention_multiple/overall-in.R"),
-  times = 5
-)
-#> Unit: milliseconds
-#>  expr      min       lq     mean   median       uq      max neval
-#>  base 930.4391 944.9253 969.2838 951.4632 951.6571 1067.934     5
-```
+    microbenchmark::microbenchmark(
+      base = style_file("tests/testthat/indention_multiple/overall-in.R"),
+      times = 5
+    )
+    #> Unit: milliseconds
+    #>  expr      min       lq     mean   median       uq      max neval
+    #>  base 930.4391 944.9253 969.2838 951.4632 951.6571 1067.934     5
 
 Various changes (positive and negative in terms of speed)
 
-```
-microbenchmark::microbenchmark(
-  base = style_file("tests/testthat/indention_multiple/overall-in.R"),
-  times = 10
-)
-#> Unit: seconds
-#> expr      min       lq     mean   median       uq      max neval
-#>  base 1.235749 1.259139 1.269869 1.269396 1.275887 1.330341    10
+    microbenchmark::microbenchmark(
+      base = style_file("tests/testthat/indention_multiple/overall-in.R"),
+      times = 10
+    )
+    #> Unit: seconds
+    #> expr      min       lq     mean   median       uq      max neval
+    #>  base 1.235749 1.259139 1.269869 1.269396 1.275887 1.330341    10
 
-```
+Removed tibble bottlenecks (tibble 1.4.2, <https://github.com/tidyverse/tibble/pull/348>)
 
-
-Removed tibble bottlenecks (tibble 1.4.2, https://github.com/tidyverse/tibble/pull/348)
-
-```
-microbenchmark::microbenchmark(
-  base = style_file("tests/testthat/indention_multiple/overall-in.R"),
-  times = 10
-)
-#> Unit: milliseconds
-#>  expr      min       lq     mean   median       uq      max neval
-#>  base 514.9392 520.5061 587.6329 530.3154 548.7248 989.3332    10
-
-```
+    microbenchmark::microbenchmark(
+      base = style_file("tests/testthat/indention_multiple/overall-in.R"),
+      times = 10
+    )
+    #> Unit: milliseconds
+    #>  expr      min       lq     mean   median       uq      max neval
+    #>  base 514.9392 520.5061 587.6329 530.3154 548.7248 989.3332    10

--- a/vignettes/remove_rules.Rmd
+++ b/vignettes/remove_rules.Rmd
@@ -3,8 +3,11 @@ title: "Remove rules"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Remove rules}
-  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
+editor_options: 
+  markdown: 
+    wrap: 79
 ---
 
 ```{r, include = FALSE}
@@ -18,47 +21,47 @@ knitr::opts_chunk$set(
 options(styler.colored_print.vertical = FALSE)
 ```
 
-If you want to change the behavior of styler to match your desired style, there 
+If you want to change the behavior of styler to match your desired style, there
 are multiple ways:
 
-- Use the tidyverse style guide, but not with the default options. Starting 
-  point for this approach is the  [help file](https://styler.r-lib.org/reference/tidyverse_style.html) for
-  the function `tidyverse_style()`, which returns the transformer functions that
-  prettify your code. Most of these options are explained in `vignette("styler")`.
+-   Use the tidyverse style guide, but not with the default options. Starting
+    point for this approach is the [help
+    file](https://styler.r-lib.org/reference/tidyverse_style.html) for the
+    function `tidyverse_style()`, which returns the transformer functions that
+    prettify your code. Most of these options are explained in
+    `vignette("styler")`.
 
-- If you can't get styler behaving the way you want using the arguments of
-  `tidyverse_style()`, you have another option, which is described in a
-  `vignette("customizing_styler")`: Creating your own style guide from scratch.
-  Yes, I admit, it's pretty long and if you don't want to become a 
-  *styler expert*, it may be a little bit overwhelming.
+-   If you can't get styler behaving the way you want using the arguments of
+    `tidyverse_style()`, you have another option, which is described in a
+    `vignette("customizing_styler")`: Creating your own style guide from
+    scratch. Yes, I admit, it's pretty long and if you don't want to become a
+    *styler expert*, it may be a little bit overwhelming.
 
-- If you don't care about how to create new rules but you simply want to *remove*
-  a rule, I have good news for you: There is a quick way to do it. And that's
-  what the remainder of this vignette focuses on.
+-   If you don't care about how to create new rules but you simply want to
+    *remove* a rule, I have good news for you: There is a quick way to do it.
+    And that's what the remainder of this vignette focuses on.
 
-Once you are happy with your style guide, you might ant to have a look at how to
-distribute it, which is described in 
+Once you are happy with your style guide, you might ant to have a look at how
+to distribute it, which is described in
 `vignette("distribute_custom_style_guides")`.
 
 # Theory
 
 Here are the steps required to deactivate a rule you don't like
 
-- Figure out which transformer function in the transformers returned by
-  `tidyerse_style()` corresponds to the rule you want to remove.
+-   Figure out which transformer function in the transformers returned by
+    `tidyerse_style()` corresponds to the rule you want to remove.
 
-- Set that element in the list to `NULL`, which is equivalent to removing it.
+-   Set that element in the list to `NULL`, which is equivalent to removing it.
 
-- Pass the list to `style_text` as a transformer.
+-   Pass the list to `style_text` as a transformer.
 
 # Practice
 
-Lets assume you want to remove the rule that turns `=` into `<-` for assignment.
-That means you want
+Lets assume you want to remove the rule that turns `=` into `<-` for
+assignment. That means you want
 
-``` 
-string = "hi there" 
-```
+    string = "hi there" 
 
 to remain unchanged after applying styler. This is not the case if you use the
 default style guide of styler:
@@ -80,9 +83,9 @@ From the aforementioned
 [vignette](https://styler.r-lib.org/articles/customizing_styler.html):
 
 > We note that there are different types of transformer functions. initialize
-initializes some variables in the nested parse table (so it is not actually a
-transformer), and the other elements modify either spacing, line breaks or
-tokens. use_raw_indention is not a function, it is just an option.
+> initializes some variables in the nested parse table (so it is not actually a
+> transformer), and the other elements modify either spacing, line breaks or
+> tokens. use_raw_indention is not a function, it is just an option.
 
 Now, we can look at the names of the rules that are sub-elements of the
 transformer categories.
@@ -118,7 +121,8 @@ And you can use the modified transformer list as input to `style_text()`
 style_text("string = 'hi there'", transformers = transformers)
 ```
 
-If you want to use it the same way as `tidyverse_style()`, here's the last step:
+If you want to use it the same way as `tidyverse_style()`, here's the last
+step:
 
 ```{r}
 eq_assign_style <- function(...) {
@@ -130,12 +134,11 @@ eq_assign_style <- function(...) {
 style_text("string = 'hi there'", style = eq_assign_style)
 ```
 
-
 That's it. Note that the transformer functions and how they are returned by
 `tidyverse_style()` is not part of the exposed API. This means that the order,
-the naming etc. may change. Also, remember we did not add a rule to replace `<-`
-with `=`, but we only removed a rule to replace `=` with `<-`, so `<-` won't be
-touched:
+the naming etc. may change. Also, remember we did not add a rule to replace
+`<-` with `=`, but we only removed a rule to replace `=` with `<-`, so `<-`
+won't be touched:
 
 ```{r}
 style_text("string <- 'hi there'", style = eq_assign_style)
@@ -146,9 +149,9 @@ If you want to turn `<-` into `=`, you need to add a rule as described in
 
 If you have trouble identifying a rule based on rule names,
 
-* First write an example whose results is not the one you wanted, e.g.
+-   First write an example whose results is not the one you wanted, e.g.
 
-```r
+``` r
 code <- "
 f <- function () {
 
@@ -156,41 +159,46 @@ return (1)
 }"
 ```
 
-is code that will have the first empty line in the function body removed by styler.
+is code that will have the first empty line in the function body removed by
+styler.
 
-* Then pinpoint the probable rule type (e.g. line breaks if you want less new lines).
-* In a local styler clone, add e.g. a `return(pd` at the top of the body to deactivate
-  the rule quickly, or add a `print(pd)` or `browser()` call in the functions
- of that type (e.g. the different functions of `R/rules-line-breaks.R`),
- `load_all()`, run your example, see if that function made the change.
- move the `print(pd)` or `browser()` call to another function if not.
- * Once you've identified the culprit (in this case `style_line_break_around_curly`),
- set it to `NULL` as shown earlier.
+-   Then pinpoint the probable rule type (e.g. line breaks if you want less new
+    lines).
+-   In a local styler clone, add e.g. a `return(pd` at the top of the body to
+    deactivate the rule quickly, or add a `print(pd)` or `browser()` call in
+    the functions of that type (e.g. the different functions of
+    `R/rules-line-breaks.R`), `load_all()`, run your example, see if that
+    function made the change. move the `print(pd)` or `browser()` call to
+    another function if not.
+-   Once you've identified the culprit (in this case
+    `style_line_break_around_curly`), set it to `NULL` as shown earlier.
 
 # Some other rules and their transformers
 
-* You don't like multi-line ifelse statements getting wrapped around curly
-  braces: `transformers$token$wrap_if_else_multi_line_in_curly`.
+-   You don't like multi-line ifelse statements getting wrapped around curly
+    braces: `transformers$token$wrap_if_else_multi_line_in_curly`.
 
-* You don't like multi-line calls to be broken before the first named argument:
-  `transformers$line_break$set_line_break_after_opening_if_call_is_multi_line`
-  (interacting with
-  `transformers$line_break$set_line_break_before_closing_call`).
+-   You don't like multi-line calls to be broken before the first named
+    argument:
+    `transformers$line_break$set_line_break_after_opening_if_call_is_multi_line`
+    (interacting with
+    `transformers$line_break$set_line_break_before_closing_call`).
 
-* You don't like the line being broken after the pipe:
-  `transformers$line_break$add_line_break_after_pipe`
+-   You don't like the line being broken after the pipe:
+    `transformers$line_break$add_line_break_after_pipe`
 
-* You don't like single quotes to be replaced by double quotes:
-  `transformers$space$fix_quotes`.
+-   You don't like single quotes to be replaced by double quotes:
+    `transformers$space$fix_quotes`.
 
-* You don't like comments to start with one space:
-  `transformers$space$start_comments_with_space`
+-   You don't like comments to start with one space:
+    `transformers$space$start_comments_with_space`
 
 I think you get the idea. I nevertheless recommend using the [tidyverse style
 guide](https://style.tidyverse.org/) as is since
 
-- it is a well-established, thought-through style.
+-   it is a well-established, thought-through style.
 
-- using a consistent style (no matter which) reduces friction in the community.
+-   using a consistent style (no matter which) reduces friction in the
+    community.
 
-If you have questions, don't hesitate to create an issue in the GitHub repo. 
+If you have questions, don't hesitate to create an issue in the GitHub repo.

--- a/vignettes/strict.Rmd
+++ b/vignettes/strict.Rmd
@@ -36,31 +36,28 @@ knitr::knit_engines$set(list(
 ))
 ```
 
-This vignette shows how output from styler might differ when `strict = FALSE`. 
-For brevity, we don't show the output of `strict = TRUE`, but it should be 
-pretty simple for the user to derive it from the bullet point(s) or simply paste the 
-code in the console to see the output.
+This vignette shows how output from styler might differ when `strict = FALSE`. For brevity, we don't show the output of `strict = TRUE`, but it should be pretty simple for the user to derive it from the bullet point(s) or simply paste the code in the console to see the output.
 
 ```{r setup}
 library(styler)
 ```
 
-* multi-line function declarations without curly braces are tolerated.
+-   multi-line function declarations without curly braces are tolerated.
 
 ```{styler}
 function()
   NULL
 ```
 
-* Spaces before opening parenthesis, tilde as well as around comments and math token must 
-  be at least one, not exactly one.
+-   Spaces before opening parenthesis, tilde as well as around comments and math token must be at least one, not exactly one.
 
 ```{styler}
 1  +    (1 + 3)
 1 ~  more()   #   comment
 ```
-* More than one line break is tolerated before closing curly brace and line 
-  breaks between curly and round braces are not removed. 
+
+-   More than one line break is tolerated before closing curly brace and line breaks between curly and round braces are not removed.
+
 ```{styler}
 test({
   1
@@ -69,8 +66,7 @@ test({
 )
 ```
 
-* Multi-line calls don't  put the closing brace on a new line nor trigger a line
-  break after the opening brace.
+-   Multi-line calls don't put the closing brace on a new line nor trigger a line break after the opening brace.
 
 ```{styler}
 call(
@@ -80,7 +76,7 @@ call(2,
 )
 ```
 
-* No line break inserted after pipes nor ggplot2 or pipe expressions.
+-   No line break inserted after pipes nor ggplot2 or pipe expressions.
 
 ```{styler}
 ggplot2::ggplot(data, aes(x, y)) + geom_line() + scale_x_continuous()
@@ -88,7 +84,7 @@ ggplot2::ggplot(data, aes(x, y)) + geom_line() + scale_x_continuous()
 this %>% is() %>% a() %>% long() %>% pipe()
 ```
 
-* ifelse statements don't get curly braces added when multi-line.
+-   ifelse statements don't get curly braces added when multi-line.
 
 ```{styler}
 if (TRUE) 3  else 

--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -25,32 +25,26 @@ knitr::knit_engines$set(list(
 
 styler provides the following API to format code:
 
-* `style_file()` styles `.R`, `.Rmd`, `.Rmarkdown`, `.Rnw`,  and `.Rprofile` 
-  files.
+-   `style_file()` styles `.R`, `.Rmd`, `.Rmarkdown`, `.Rnw`, and `.Rprofile` files.
 
-* `style_dir()` styles all these files in a directory.
+-   `style_dir()` styles all these files in a directory.
 
-* `style_pkg()` styles the source files of an R package.
+-   `style_pkg()` styles the source files of an R package.
 
-* RStudio Addins for styling the active file, styling the current package and
-  styling the highlighted selection, see `help("styler_addins")`.
+-   RStudio Addins for styling the active file, styling the current package and styling the highlighted selection, see `help("styler_addins")`.
 
-Beyond that, styler can be used through other tools documented in the
-`vignette("third-party-integrations")`.
+Beyond that, styler can be used through other tools documented in the `vignette("third-party-integrations")`.
 
 ### Passing arguments to the style guide
 
-styler separates the abstract definition of a style guide from the application
-of it. That's why you must supply a style guide via `transformers` when
-styling (in case you don't want to rely on the defaults):
+styler separates the abstract definition of a style guide from the application of it. That's why you must supply a style guide via `transformers` when styling (in case you don't want to rely on the defaults):
 
 ```{r}
 library(styler)
 style_text("a + b", transformers = tidyverse_style(scope = "indention"))
 ```
 
-The styler API was designed so that you can pass arguments to the style guide
-via the styling function (e.g. `style_file()`) to allow more concise syntax:
+The styler API was designed so that you can pass arguments to the style guide via the styling function (e.g. `style_file()`) to allow more concise syntax:
 
 ```{r, results = 'hide'}
 # equivalent
@@ -60,33 +54,27 @@ style_text("a + b", scope = "indention")
 
 The magic is possible thanks to `...`. See `style_text()` for details.
 
-# Invasiveness 
+# Invasiveness
 
-### `scope`: What to style? 
+### `scope`: What to style?
 
-This argument of `tidyverse_style()` determines the invasiveness of styling. The
-following levels for `scope` are available (in increasing order):
+This argument of `tidyverse_style()` determines the invasiveness of styling. The following levels for `scope` are available (in increasing order):
 
-* "none": Performs no transformation at all.
+-   "none": Performs no transformation at all.
 
-* "spaces": Manipulates spacing between token on the same line.
+-   "spaces": Manipulates spacing between token on the same line.
 
-* "indention": Manipulates the indention, i.e. number of spaces at the beginning
-  of each line.
+-   "indention": Manipulates the indention, i.e. number of spaces at the beginning of each line.
 
-* "line_breaks": Manipulates line breaks between tokens.
+-   "line_breaks": Manipulates line breaks between tokens.
 
-* "tokens": manipulates tokens.
+-   "tokens": manipulates tokens.
 
 There are two ways to specify the scope of styling.
 
-* As a string: In this case all less invasive scope levels are implied, e.g.
-  `"line_breaks"` includes `"indention"`, `"spaces"`. This is brief and what
-  most users need. This is supported in `styler >= 1.0.0`.
+-   As a string: In this case all less invasive scope levels are implied, e.g. `"line_breaks"` includes `"indention"`, `"spaces"`. This is brief and what most users need. This is supported in `styler >= 1.0.0`.
 
-* As vector of class `AsIs`: Each level has to be listed explicitly by wrapping
-  one ore more levels of the scope in `I()`. This offers more granular control
-  at the expense of more verbosity. This is supported in `styler > 1.3.2`.
+-   As vector of class `AsIs`: Each level has to be listed explicitly by wrapping one ore more levels of the scope in `I()`. This offers more granular control at the expense of more verbosity. This is supported in `styler > 1.3.2`.
 
 ```{r}
 # tokens and everything less invasive
@@ -96,16 +84,12 @@ style_text("a=2", scope = "tokens")
 style_text("a=2", scope = I(c("tokens", "indention")))
 ```
 
-As you can see from the output, the assignment operator `=` is replaced with
-`<-` in both cases, but spacing remained unchanged in the second example.
+As you can see from the output, the assignment operator `=` is replaced with `<-` in both cases, but spacing remained unchanged in the second example.
 
 ### How `strict` do you want styler to be?
 
-Another option that is helpful to determine the level of 'invasiveness' is
-`strict` (defaulting to `TRUE`). Some rules won't be applied so strictly with
-`strict = FALSE`, assuming you deliberately formatted things the way they are.
-Please see in `vignette("strict")`. For `styler >= 1.2` alignment in function
-calls is detected and preserved so you don't need `strict = FALSE`, e.g.
+Another option that is helpful to determine the level of 'invasiveness' is `strict` (defaulting to `TRUE`). Some rules won't be applied so strictly with `strict = FALSE`, assuming you deliberately formatted things the way they are. Please see in `vignette("strict")`. For `styler >= 1.2` alignment in function calls is detected and preserved so you don't need `strict = FALSE`, e.g.
+
 ```{r}
 style_text(
   "tibble::tibble(
@@ -120,9 +104,7 @@ The details are in `vignette("detect-alignment")`.
 
 # Ignoring certain lines
 
-You can tell styler to ignore some lines if you want to keep current formatting.
-You can mark whole blocks or inline expressions with `styler: on` and `styler:
-off`:
+You can tell styler to ignore some lines if you want to keep current formatting. You can mark whole blocks or inline expressions with `styler: on` and `styler: off`:
 
 ```{r}
 styler::style_text(
@@ -142,38 +124,24 @@ styler::style_text(
 "
 )
 ```
-You can also use custom markers as described in 
-`help("stylerignore", package = "styler")`. As described above and in
-`vignette("detect-alignment")`,
-some alignment is recognized and hence, *stylerignore* should not 
-be necessary in that context.
+
+You can also use custom markers as described in `help("stylerignore", package = "styler")`. As described above and in `vignette("detect-alignment")`, some alignment is recognized and hence, *stylerignore* should not be necessary in that context.
 
 # Caching
 
-styler is rather slow, so leveraging a cache for styled code brings big speedups
-in many situations. Starting with version `1.3.0`, you can benefit from it. For
-people using styler interactively (e.g. in RStudio), typing
-`styler::cache_info()` and then confirming the creation of a permanent cache is
-sufficient. Please refer to `help("caching")` for more information. The cache is
-by default dependent on the version of styler which means if you upgrade, the
-cache will be re-built. Also, the cache takes literally 0 disk space because
-only the hash of styled code is stored.
+styler is rather slow, so leveraging a cache for styled code brings big speedups in many situations. Starting with version `1.3.0`, you can benefit from it. For people using styler interactively (e.g. in RStudio), typing `styler::cache_info()` and then confirming the creation of a permanent cache is sufficient. Please refer to `help("caching")` for more information. The cache is by default dependent on the version of styler which means if you upgrade, the cache will be re-built. Also, the cache takes literally 0 disk space because only the hash of styled code is stored.
 
 # Dry mode
 
-As of version `1.3.2`, styler has a dry mode which avoids writing output to the
-file(s) you want to format. The following options are available:
+As of version `1.3.2`, styler has a dry mode which avoids writing output to the file(s) you want to format. The following options are available:
 
-- *off* (default): Write back to the file if applying styling changes the
-  input.
+-   *off* (default): Write back to the file if applying styling changes the input.
 
-- *on*: Applies styling and returns the results without writing changes (if any) back to the file(s).
+-   *on*: Applies styling and returns the results without writing changes (if any) back to the file(s).
 
-- *fail*: returns an error if the result of styling is not identical to the
-  input.
+-   *fail*: returns an error if the result of styling is not identical to the input.
 
-In any case, you can use the (invisible) return value of `style_file()` and
-friends to learn how files were changed (or would have changed):
+In any case, you can use the (invisible) return value of `style_file()` and friends to learn how files were changed (or would have changed):
 
 ```{r}
 out <- withr::with_tempfile(
@@ -200,9 +168,7 @@ This is enabled by default, you can turn it off with `include_roxygen_examples =
 1++1-1-1/2
 ```
 
-This is tidyverse style. However, styler offers very granular control for math
-token spacing. Assuming you like spacing around `+` and `-`, but not around `/`
-and `*` and `^`, do the following:
+This is tidyverse style. However, styler offers very granular control for math token spacing. Assuming you like spacing around `+` and `-`, but not around `/` and `*` and `^`, do the following:
 
 ```{r}
 style_text(
@@ -213,9 +179,7 @@ style_text(
 
 ### Custom indention
 
-If you, say, don't want comments starting with `###` to be indented and
-indention to be 4 instead of two spaces, you can formulate an unindention rule
-and set `indent_by` to 4:
+If you, say, don't want comments starting with `###` to be indented and indention to be 4 instead of two spaces, you can formulate an unindention rule and set `indent_by` to 4:
 
 ```{r}
 style_text(
@@ -233,12 +197,7 @@ style_text(
 
 ### Custom style guides
 
-These verse some (not all) configurations exposed in `style_file()` and friends
-as well as `tidyverse_style()`. If the above did not give you the flexibility
-you hoped for, your can create your own style guide and customize styler even
-further:
+These verse some (not all) configurations exposed in `style_file()` and friends as well as `tidyverse_style()`. If the above did not give you the flexibility you hoped for, your can create your own style guide and customize styler even further:
 
-* either by removing rules from the tidyverse style guide as described in
-  `vignette("remove_rules")`.
-* or by creating your own style guide from scratch as described in 
-  `vignette("customizing_styler")`.
+-   either by removing rules from the tidyverse style guide as described in `vignette("remove_rules")`.
+-   or by creating your own style guide from scratch as described in `vignette("customizing_styler")`.

--- a/vignettes/third-party-integrations.Rmd
+++ b/vignettes/third-party-integrations.Rmd
@@ -16,50 +16,26 @@ knitr::opts_chunk$set(
 
 styler functionality is available in other tools, most notably
 
-* as a pre-commit hook `style-files` in
-  <https://github.com/lorenzwalthert/precommit> to format before commit 
-  (locally) and enforced as a continuous integration step in the cloud through
-  <https://pre-commit.ci>.
+-   as a pre-commit hook `style-files` in <https://github.com/lorenzwalthert/precommit> to format before commit (locally) and enforced as a continuous integration step in the cloud through <https://pre-commit.ci>.
 
-* via `usethis::use_tidy_style()` styles your project according to the tidyverse
-  style guide.
+-   via `usethis::use_tidy_style()` styles your project according to the tidyverse style guide.
 
-* through commenting a PR on GitHub with `\style` when the [GitHub
-  Action](https://github.com/features/actions) [*Tidyverse
-  CI*](https://github.com/r-lib/actions/tree/master/examples#tidyverse-ci-workflow)
-  is used. The most convenient way to set this up is via
-  [`usethis::use_tidy_github_actions()`](https://usethis.r-lib.org/reference/tidyverse.html).
+-   through commenting a PR on GitHub with `\style` when the [GitHub Action](https://github.com/features/actions) [*Tidyverse CI*](https://github.com/r-lib/actions/tree/master/examples#tidyverse-ci-workflow) is used. The most convenient way to set this up is via [`usethis::use_tidy_github_actions()`](https://usethis.r-lib.org/reference/tidyverse.html).
 
-* through the [GitHub Action Workflow](https://github.com/r-lib/actions/tree/v2-branch/examples#style-package) that triggers `styler::style_pkg()`
-  on changes in source files.
+-   through the [GitHub Action Workflow](https://github.com/r-lib/actions/tree/v2-branch/examples#style-package) that triggers `styler::style_pkg()` on changes in source files.
 
-* as a formatter for R Markdown without modifying the source. This feature is
-  implemented as a code chunk option in knitr. use `tidy = "styler"` in the
-  header of a code chunks (e.g.` ```{r name-of-the-chunk, tidy = "styler"} `),
-  or `knitr::opts_chunk$set(tidy = "styler")` at the top of your RMarkdown
-  script.
+-   as a formatter for R Markdown without modifying the source. This feature is implemented as a code chunk option in knitr. use `tidy = "styler"` in the header of a code chunks (e.g.```` ```{r name-of-the-chunk, tidy = "styler"} ````), or `knitr::opts_chunk$set(tidy = "styler")` at the top of your RMarkdown script.
 
-* via the [R language server](https://github.com/REditorSupport/languageserver) 
-  to format your code in VS Code, atom and others.
+-   via the [R language server](https://github.com/REditorSupport/languageserver) to format your code in VS Code, atom and others.
 
-* As a fixer to the [ale
-  Plug-in](https://github.com/dense-analysis/ale/pull/2401) for VIM.
+-   As a fixer to the [ale Plug-in](https://github.com/dense-analysis/ale/pull/2401) for VIM.
 
-* in `reprex::reprex(..., style = TRUE)` to prettify reprex code before
-  printing. To permanently use `style = TRUE` without specifying it every time,
-  you can add the following line to your `.Rprofile` (via
-  `usethis::edit_r_profile()`): `options(reprex.styler = TRUE)`.
+-   in `reprex::reprex(..., style = TRUE)` to prettify reprex code before printing. To permanently use `style = TRUE` without specifying it every time, you can add the following line to your `.Rprofile` (via `usethis::edit_r_profile()`): `options(reprex.styler = TRUE)`.
 
+-   in the *format-all* command for Emacs in [emacs-format-all-the-code](https://github.com/lassik/emacs-format-all-the-code).
 
-* in the *format-all* command for Emacs in 
-  [emacs-format-all-the-code](https://github.com/lassik/emacs-format-all-the-code).
+-   As a [Jupyterlab code formatter](https://jupyterlab-code-formatter.readthedocs.io/en/latest/installation.html#r-code-formatters).
 
-* As a [Jupyterlab code
-  formatter](https://jupyterlab-code-formatter.readthedocs.io/en/latest/installation.html#r-code-formatters).
+-   for pretty-printing [drake](https://github.com/ropensci/drake) workflow data frames with `drake::drake_plan_source()`.
 
-* for pretty-printing [drake](https://github.com/ropensci/drake) workflow data
-  frames with `drake::drake_plan_source()`.
-
-Do you know another way to use styler that is not listed here? Please let us know
-by [opening an issue](https://github.com/r-lib/styler/issues) and we'll extend the
-list.
+Do you know another way to use styler that is not listed here? Please let us know by [opening an issue](https://github.com/r-lib/styler/issues) and we'll extend the list.


### PR DESCRIPTION
This also uses line wrapping, which means that one paragraph is on one line, but it is displayed as if it lives on different lines: 

<img width="755" alt="Screenshot 2022-04-18 at 10 19 00" src="https://user-images.githubusercontent.com/10477073/163779308-7cff3719-9346-44ae-9f56-e41518062d46.png">