### PR TITLE
More strict formatting around `{` and `#`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ editor_options:
 
 -   If there are only empty lines in a code chunk, they are all removed (#936).
 
+-   There is now always one line break after `{` and before `#` (#916).
+
 -   the cache is also invalidated on changing the stylerignore markers (#932).
 
 -   `{` is not put on a new line after `=` and in `function() {` for some edge

--- a/R/rules-line-breaks.R
+++ b/R/rules-line-breaks.R
@@ -144,7 +144,7 @@ set_line_break_around_comma_and_or <- function(pd, strict) {
 style_line_break_around_curly <- function(strict, pd) {
   if (is_curly_expr(pd) && nrow(pd) > 2) {
     closing_before <- pd$token == "'}'"
-    opening_before <- (pd$token == "'{'") & (pd$token_after != "COMMENT")
+    opening_before <- (pd$token == "'{'")
     to_break <- lag(opening_before, default = FALSE) | closing_before
     len_to_break <- sum(to_break)
     pd$lag_newlines[to_break] <- ifelse(rep(strict, len_to_break),

--- a/tests/testthat/indention_multiple/overall-out.R
+++ b/tests/testthat/indention_multiple/overall-out.R
@@ -8,7 +8,8 @@ a <- function(x) {
       22 + 1
     ))
     if (x > 10) {
-      for (x in 22) { # FIXME in operator only to be surrounded by one space. What about %in%?
+      for (x in 22) {
+        # FIXME in operator only to be surrounded by one space. What about %in%?
         prin(x)
       }
     }

--- a/tests/testthat/line_breaks_and_other/curly-in.R
+++ b/tests/testthat/line_breaks_and_other/curly-in.R
@@ -31,3 +31,13 @@ test_that("I am here", {
   a_test(x)
 }
 )
+
+test_that(
+  desc = "bla",
+  code = {
+
+
+
+    # comment
+    expect_equal(1 + 1, 2)
+  })

--- a/tests/testthat/line_breaks_and_other/curly-out.R
+++ b/tests/testthat/line_breaks_and_other/curly-out.R
@@ -30,3 +30,11 @@ if (1 > 3) {
 test_that("I am here", {
   a_test(x)
 })
+
+test_that(
+  desc = "bla",
+  code = {
+    # comment
+    expect_equal(1 + 1, 2)
+  }
+)


### PR DESCRIPTION
Closes #951.