### PR TITLE
Avoid ANSI escapes on website

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@ editor_options:
 
 **Other**
 
+-   Old (and outdated) vignettes have been removed (\@IndrajeetPatil, #955).
+    To access them, do `git checkout v1.0.0`.
 -   Upgrade testing infra to testthat 3e (\@IndrajeetPatil, #949).
 -   All (R)md files in this project's source code are now formatted with
     default pandoc markdown formatter. This conversion is required when using

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,8 @@ editor_options:
     the visual mode in RStudio (#941).
 -   Update {pkgdown} action to always build, but only deploy on default branch
     (#946).
+-   turned off `styler.print.Vertical` in vignettes so ANSI output of {prettycode} 
+    not messing with {pkgdown} (#956, \@IndrajeetPatil). 
 
 # styler 1.7.0
 

--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -19,6 +19,8 @@ knitr::knit_engines$set(list(
     )
   }
 ))
+
+options(styler.colored_print.vertical = FALSE)
 ```
 
 # Entry-points


### PR DESCRIPTION
Closes #954

I created a local website for the package and can confirm that the suggested solution indeed solves the issue.