### PR TITLE
fix ANSI escape sequences issues

### DIFF
--- a/vignettes/styler.Rmd
+++ b/vignettes/styler.Rmd
@@ -145,7 +145,7 @@ As of version `1.3.2`, styler has a dry mode which avoids writing output to the 
 
 In any case, you can use the (invisible) return value of `style_file()` and friends to learn how files were changed (or would have changed):
 
-```{r}
+```{r, comment = "#>"}
 out <- withr::with_tempfile(
   "code.R",
   {


### PR DESCRIPTION
Follow up on #956
Related to #954

This indeed fixes the issue for that chunk:

<img width="522" alt="Screenshot 2022-06-16 at 16 55 54" src="https://user-images.githubusercontent.com/11330453/174099513-c50a954c-3a38-4a05-9ed9-a5c60468ca1a.png">
