### PR TITLE
Optimize visiting code

### DIFF
--- a/R/initialize.R
+++ b/R/initialize.R
@@ -10,7 +10,7 @@
 #'   {
 #'     string_to_format <- "call( 3)"
 #'     pd <- styler:::compute_parse_data_nested(string_to_format)
-#'     styler:::pre_visit(pd, c(default_style_guide_attributes))
+#'     styler:::pre_visit_one(pd, default_style_guide_attributes)
 #'   }
 #' )
 #' @export

--- a/R/nested-to-tree.R
+++ b/R/nested-to-tree.R
@@ -8,7 +8,7 @@
 #' @keywords internal
 create_tree <- function(text, structure_only = FALSE) {
   compute_parse_data_nested(text, transformers = NULL) %>%
-    pre_visit(c(default_style_guide_attributes)) %>%
+    pre_visit_one(default_style_guide_attributes) %>%
     create_tree_from_pd_with_default_style_attributes(structure_only)
 }
 
@@ -36,8 +36,8 @@ create_tree_from_pd_with_default_style_attributes <- function(pd,
 #'     {
 #'       code <- "a <- function(x) { if(x > 1) { 1+1 } else {x} }"
 #'       nested_pd <- styler:::compute_parse_data_nested(code)
-#'       initialized <- styler:::pre_visit(
-#'         nested_pd, c(default_style_guide_attributes)
+#'       initialized <- styler:::pre_visit_one(
+#'         nested_pd, default_style_guide_attributes
 #'       )
 #'       styler:::create_node_from_nested_root(initialized,
 #'         structure_only = FALSE

--- a/R/relevel.R
+++ b/R/relevel.R
@@ -12,8 +12,7 @@
 #' @param pd_nested A nested parse table to partially flatten.
 #' @keywords internal
 flatten_operators <- function(pd_nested) {
-  pd_nested %>%
-    post_visit(c(flatten_operators_one))
+  post_visit_one(pd_nested, flatten_operators_one)
 }
 
 #' Flatten one level of nesting with its child
@@ -144,8 +143,7 @@ wrap_expr_in_expr <- function(pd) {
 #' @keywords internal
 relocate_eq_assign <- function(pd) {
   if (parser_version_get() < 2) {
-    pd %>%
-      post_visit(c(relocate_eq_assign_nest))
+    post_visit_one(pd, relocate_eq_assign_nest)
   } else {
     pd
   }

--- a/R/transform-block.R
+++ b/R/transform-block.R
@@ -28,7 +28,7 @@ parse_transform_serialize_r_block <- function(pd_nested,
                                               base_indention) {
   if (!all(pd_nested$is_cached, na.rm = TRUE) || !cache_is_activated()) {
     transformed_pd <- apply_transformers(pd_nested, transformers)
-    flattened_pd <- post_visit(transformed_pd, list(extract_terminals)) %>%
+    flattened_pd <- post_visit_one(transformed_pd, extract_terminals) %>%
       enrich_terminals(transformers$use_raw_indention) %>%
       apply_ref_indention() %>%
       set_regex_indention(

--- a/R/visit.R
+++ b/R/visit.R
@@ -20,9 +20,19 @@ pre_visit <- function(pd_nested, funs) {
   if (is.null(pd_nested)) {
     return()
   }
+  if (length(funs) == 0) {
+    return(pd_nested)
+  }
   pd_nested <- visit_one(pd_nested, funs)
 
-  pd_nested$child <- map(pd_nested$child, pre_visit, funs = funs)
+  children <- pd_nested$child
+  for (i in seq_along(children)) {
+    child <- children[[i]]
+    if (!is.null(child)) {
+      children[[i]] <- pre_visit(child, funs)
+    }
+  }
+  pd_nested$child <- children
   pd_nested
 }
 
@@ -32,8 +42,19 @@ post_visit <- function(pd_nested, funs) {
   if (is.null(pd_nested)) {
     return()
   }
+  if (length(funs) == 0) {
+    return(pd_nested)
+  }
 
-  pd_nested$child <- map(pd_nested$child, post_visit, funs = funs)
+  children <- pd_nested$child
+  for (i in seq_along(children)) {
+    child <- children[[i]]
+    if (!is.null(child)) {
+      children[[i]] <- post_visit(child, funs)
+    }
+  }
+  pd_nested$child <- children
+
   visit_one(pd_nested, funs)
 }
 
@@ -46,7 +67,10 @@ post_visit <- function(pd_nested, funs) {
 #' @family visitors
 #' @keywords internal
 visit_one <- function(pd_flat, funs) {
-  Reduce(function(x, fun) fun(x), funs, init = pd_flat)
+  for (f in funs) {
+    pd_flat <- f(pd_flat)
+  }
+  pd_flat
 }
 
 #' Propagate context to terminals

--- a/R/visit.R
+++ b/R/visit.R
@@ -38,6 +38,25 @@ pre_visit <- function(pd_nested, funs) {
 
 #' @rdname visit
 #' @keywords internal
+pre_visit_one <- function(pd_nested, fun) {
+  if (is.null(pd_nested)) {
+    return()
+  }
+  pd_nested <- fun(pd_nested)
+
+  children <- pd_nested$child
+  for (i in seq_along(children)) {
+    child <- children[[i]]
+    if (!is.null(child)) {
+      children[[i]] <- pre_visit_one(child, fun)
+    }
+  }
+  pd_nested$child <- children
+  pd_nested
+}
+
+#' @rdname visit
+#' @keywords internal
 post_visit <- function(pd_nested, funs) {
   if (is.null(pd_nested)) {
     return()
@@ -56,6 +75,26 @@ post_visit <- function(pd_nested, funs) {
   pd_nested$child <- children
 
   visit_one(pd_nested, funs)
+}
+
+#' @rdname visit
+#' @keywords internal
+post_visit_one <- function(pd_nested, fun) {
+  if (is.null(pd_nested)) {
+    return()
+  }
+  force(fun)
+
+  children <- pd_nested$child
+  for (i in seq_along(children)) {
+    child <- children[[i]]
+    if (!is.null(child)) {
+      children[[i]] <- post_visit_one(child, fun)
+    }
+  }
+  pd_nested$child <- children
+
+  fun(pd_nested)
 }
 
 #' Transform a flat parse table with a list of transformers

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -30,6 +30,7 @@ coventions
 covr
 cran
 cre
+cynkra
 datastructures
 dec
 deps
@@ -95,6 +96,7 @@ ixmypi
 ized
 Jupyterlab
 Kirill
+kirill
 knitr
 krlmlr
 labelled
@@ -128,6 +130,7 @@ nph
 NUM
 oldrel
 oneliner
+ORCID
 os
 ourself
 packagemanager
@@ -149,8 +152,8 @@ prettycode
 PRs
 purrr
 qmd
-questionr
 Qmd
+questionr
 rcmdcheck
 RcppExports
 rds

--- a/man/create_node_from_nested_root.Rd
+++ b/man/create_node_from_nested_root.Rd
@@ -27,8 +27,8 @@ if (rlang::is_installed("data.tree")) {
     {
       code <- "a <- function(x) { if(x > 1) { 1+1 } else {x} }"
       nested_pd <- styler:::compute_parse_data_nested(code)
-      initialized <- styler:::pre_visit(
-        nested_pd, c(default_style_guide_attributes)
+      initialized <- styler:::pre_visit_one(
+        nested_pd, default_style_guide_attributes
       )
       styler:::create_node_from_nested_root(initialized,
         structure_only = FALSE

--- a/man/default_style_guide_attributes.Rd
+++ b/man/default_style_guide_attributes.Rd
@@ -19,7 +19,7 @@ withr::with_options(
   {
     string_to_format <- "call( 3)"
     pd <- styler:::compute_parse_data_nested(string_to_format)
-    styler:::pre_visit(pd, c(default_style_guide_attributes))
+    styler:::pre_visit_one(pd, default_style_guide_attributes)
   }
 )
 }

--- a/man/visit.Rd
+++ b/man/visit.Rd
@@ -3,12 +3,18 @@
 \name{visit}
 \alias{visit}
 \alias{pre_visit}
+\alias{pre_visit_one}
 \alias{post_visit}
+\alias{post_visit_one}
 \title{Visit'em all}
 \usage{
 pre_visit(pd_nested, funs)
 
+pre_visit_one(pd_nested, fun)
+
 post_visit(pd_nested, funs)
+
+post_visit_one(pd_nested, fun)
 }
 \arguments{
 \item{pd_nested}{A nested parse table.}

--- a/vignettes/customizing_styler.Rmd
+++ b/vignettes/customizing_styler.Rmd
@@ -40,7 +40,7 @@ As the name says, this function removes spaces after the opening parenthesis. Bu
 ```{r}
 string_to_format <- "call( 3)"
 pd <- styler:::compute_parse_data_nested(string_to_format) %>%
-  styler:::pre_visit(c(default_style_guide_attributes))
+  styler:::pre_visit_one(default_style_guide_attributes)
 pd$child[[1]] %>%
   select(token, terminal, text, newlines, spaces)
 ```


### PR DESCRIPTION
For #558 and #759.

This is a tad faster and enables cleaner stack traces, in particular recursive calls now follow each other directly, without an interleaving `map()`. We now can profile, flatten recursive calls, and get a clean picture where time is actually spent.