### PR TITLE
Use more efficient `match()` alternative

### DIFF
--- a/R/detect-alignment-utils.R
+++ b/R/detect-alignment-utils.R
@@ -111,14 +111,12 @@ alignment_ensure_trailing_comma <- function(pd_by_line) {
 #' @keywords internal
 alignment_col1_all_named <- function(relevant_pd_by_line) {
   map_lgl(relevant_pd_by_line, function(x) {
-    if (nrow(x) < 3) {
+    if (nrow(x) < 3L) {
       return(FALSE)
     }
     x$token[3] == "expr" &&
-      x$token[1] %in% c("SYMBOL_SUB", "STR_CONST", "SYMBOL_FORMALS") &&
-      x$token[2] %in% c(
-        "EQ_SUB", "EQ_FORMALS", "SPECIAL-IN", "LT", "GT", "EQ", "NE"
-      )
+      any(c("SYMBOL_SUB", "STR_CONST", "SYMBOL_FORMALS") == x$token[1]) &&
+      any(c("EQ_SUB", "EQ_FORMALS", "SPECIAL-IN", "LT", "GT", "EQ", "NE") == x$token[2])
   }) %>%
     all()
 }

--- a/R/indent.R
+++ b/R/indent.R
@@ -33,7 +33,7 @@ indent_without_paren_for_while_fun <- function(pd, indent_by) {
 #' @keywords internal
 indent_without_paren_if_else <- function(pd, indent_by) {
   expr_after_if <- next_non_comment(pd, which(pd$token == "')'")[1])
-  is_if <- pd$token[1] %in% "IF"
+  is_if <- pd$token[1] == "IF"
   has_if_without_curly <-
     is_if && pd$child[[expr_after_if]]$token[1] != "'{'"
   if (!is_if) {

--- a/R/rules-line-breaks.R
+++ b/R/rules-line-breaks.R
@@ -70,7 +70,7 @@ set_line_break_before_curly_opening <- function(pd) {
       TRUE, (line_break_to_set_idx + 1L) == last_expr_idx
     )
 
-    no_line_break_before_curly_idx <- pd$token[line_break_to_set_idx] %in% "EQ_SUB"
+    no_line_break_before_curly_idx <- any(pd$token[line_break_to_set_idx] == "EQ_SUB")
     linebreak_before_curly <- ifelse(is_function_call(pd),
       # if in function call and has pipe, it is not recognized as function call
       # and goes to else case

--- a/R/rules-line-breaks.R
+++ b/R/rules-line-breaks.R
@@ -65,7 +65,7 @@ set_line_break_before_curly_opening <- function(pd) {
       ~ next_terminal(pd[.x, ], vars = "token_after")$token_after
     ) != "'{'"
     last_expr_idx <- max(which(pd$token == "expr"))
-    is_last_expr <- ifelse(pd$token[1] %in% c("IF", "WHILE"),
+    is_last_expr <- ifelse(any(c("IF", "WHILE") == pd$token[1]),
       # rule not applicable for if and while
       TRUE, (line_break_to_set_idx + 1L) == last_expr_idx
     )
@@ -85,7 +85,7 @@ set_line_break_before_curly_opening <- function(pd) {
           no_line_break_before_curly_idx
       )
     is_not_curly_curly_idx <- line_break_to_set_idx[should_be_on_same_line]
-    pd$lag_newlines[1 + is_not_curly_curly_idx] <- 0L
+    pd$lag_newlines[1L + is_not_curly_curly_idx] <- 0L
 
 
     # other cases: line breaks
@@ -99,10 +99,10 @@ set_line_break_before_curly_opening <- function(pd) {
     ]
     if (is_function_dec(pd)) {
       should_not_be_on_same_line_idx <- setdiff(
-        1 + should_not_be_on_same_line_idx, nrow(pd)
+        1L + should_not_be_on_same_line_idx, nrow(pd)
       )
     } else {
-      should_not_be_on_same_line_idx <- 1 + should_not_be_on_same_line_idx
+      should_not_be_on_same_line_idx <- 1L + should_not_be_on_same_line_idx
     }
     pd$lag_newlines[should_not_be_on_same_line_idx] <- 1L
 
@@ -150,7 +150,7 @@ set_line_break_around_comma_and_or <- function(pd, strict) {
 }
 
 style_line_break_around_curly <- function(strict, pd) {
-  if (is_curly_expr(pd) && nrow(pd) > 2) {
+  if (is_curly_expr(pd) && nrow(pd) > 2L) {
     closing_before <- pd$token == "'}'"
     opening_before <- (pd$token == "'{'")
     to_break <- lag(opening_before, default = FALSE) | closing_before

--- a/R/ui-caching.R
+++ b/R/ui-caching.R
@@ -85,7 +85,7 @@ cache_info <- function(cache_name = NULL, format = "both") {
     location = path_cache,
     activated = cache_is_activated(cache_name)
   )
-  if (format %in% c("lucid", "both")) {
+  if (any(c("lucid", "both") == format)) {
     cat(
       "Size:\t\t", tbl$size, " bytes (", tbl$n, " cached expressions)",
       "\nLast modified:\t", as.character(tbl$last_modified),


### PR DESCRIPTION
``` r
bench::mark("x" %in% letters, any(letters == "x"))
#> # A tibble: 2 × 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 "x" %in% letters       369ns    492ns  1157064.      256B       0 
#> 2 any(letters == "x")    246ns    287ns  2157463.        0B     216.
```

<sup>Created on 2022-09-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>