### PR TITLE
Fix R CMD CHECK NOTE on detritus in temp dir

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -59,3 +59,4 @@ jobs:
           error-on: '"note"'
         env:
           _R_CHECK_FORCE_SUGGESTS_: false
+          _R_CHECK_THINGS_IN_TEMP_DIR_: true


### PR DESCRIPTION
As the [docs](https://rstudio.github.io/r-manuals/r-ints/Tools.html) says, this seems already actived with `--as-cran` (and GitHub Actions confirm). Anways, we can't actually reproduce it like this because fedorra is none of the supported platforms with our R cmd check workflows.