### PR TITLE
rename the not exported set_linebreak_after_ggplot2_plus to be consis…

### DIFF
--- a/R/rules-line-breaks.R
+++ b/R/rules-line-breaks.R
@@ -390,7 +390,7 @@ remove_line_break_in_fun_call <- function(pd, strict) {
 }
 
 
-set_linebreak_after_ggplot2_plus <- function(pd) {
+set_line_break_after_ggplot2_plus <- function(pd) {
   # if expression is unary, first token is +. Exclude this case.
   is_plus_raw <- c(FALSE, pd$token[-1L] == "'+'")
   if (any(is_plus_raw)) {

--- a/R/style-guides.R
+++ b/R/style-guides.R
@@ -165,8 +165,8 @@ tidyverse_style <- function(scope = "tokens",
         strict = strict
       ),
       add_line_break_after_pipe = if (strict) add_line_break_after_pipe,
-      set_linebreak_after_ggplot2_plus = if (strict) {
-        set_linebreak_after_ggplot2_plus
+      set_line_break_after_ggplot2_plus = if (strict) {
+        set_line_break_after_ggplot2_plus
       }
     )
   }

--- a/tests/testthat/test-transformers-drop.R
+++ b/tests/testthat/test-transformers-drop.R
@@ -76,7 +76,7 @@ test_that("tidyverse transformers are correctly dropped", {
     "set_line_break_after_opening_if_call_is_multi_line",
     "set_line_break_before_closing_call",
     "remove_line_break_in_fun_call",
-    "set_linebreak_after_ggplot2_plus"
+    "set_line_break_after_ggplot2_plus"
   )
   expect_setequal(names(t_fun$line_break), names_line_break)
 


### PR DESCRIPTION
closes #1048 

Now all set_line_break_* functions have consistent naming.

As the `set_linebreak_after_ggplot2_plus` is not exported I think we do not have to add the record to NEWS file i.e. add the */- to commit message.