### PR TITLE
`...` in `withr::local_options()` was introduced only in v.2.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     rprojroot (>= 1.1),
     tools,
     vctrs (>= 0.4.1),
-    withr (>= 1.0.0),
+    withr (>= 2.3.0),
 Suggests: 
     data.tree (>= 0.1.6),
     digest,


### PR DESCRIPTION
Addresses warning about unused argument in #1050.