### PR TITLE
Add lintr config file to Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,6 +9,7 @@
 ^\.Rproj\.user$
 ^\.github$
 ^\.gitsum$
+^\.lintr$
 ^\.pre-commit-config\.yaml$
 ^_pkgdown\.yaml$
 ^cran-comments\.md$


### PR DESCRIPTION
Builds are failing on `main` due to this issue. 