### PR TITLE
Check if all examples run successfully

### DIFF
--- a/.github/workflows/check-all-examples.yaml
+++ b/.github/workflows/check-all-examples.yaml
@@ -1,0 +1,42 @@
+# Make sure all examples run successfully, even the ones that are not supposed
+# to be run or tested on CRAN machines by default.
+#
+# The examples that fail should use
+#  - `if (FALSE) { ... }` (if example is included only for illustrative purposes)
+#  - `try({ ... })` (if the intent is to show the error)
+#
+# This workflow helps find such failing examples that need to be modified.
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: check-all-examples
+
+jobs:
+  check-all-examples:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          pak-version: devel
+          extra-packages: |
+            any::devtools
+            local::.
+
+      - name: Run examples
+        run: |
+          options(crayon.enabled = TRUE)
+          devtools::run_examples(fresh = TRUE, run_dontrun = TRUE, run_donttest = TRUE)
+        shell: Rscript {0}

--- a/R/parse.R
+++ b/R/parse.R
@@ -8,12 +8,11 @@
 #' @param ... Parameters passed to [base::parse()].
 #' @keywords internal
 #' @examples
-#' \dontrun{
 #' try(styler:::parse_safely("a + 3 -4 -> x\r\n glück + 1"))
 #' # This cannot be detected as a EOL style problem because the first
 #' # line ends as expected with \n
 #' try(styler:::parse_safely("a + 3 -4 -> x\nx + 2\r\n glück + 1"))
-#' }
+#'
 #' styler:::parse_safely("a + 3 -4 -> \n glück + 1")
 parse_safely <- function(text, ...) {
   tried_parsing <- rlang::with_handlers(

--- a/R/parse.R
+++ b/R/parse.R
@@ -9,10 +9,10 @@
 #' @keywords internal
 #' @examples
 #' \dontrun{
-#' styler:::parse_safely("a + 3 -4 -> x\r\n glück + 1")
+#' try(styler:::parse_safely("a + 3 -4 -> x\r\n glück + 1"))
 #' # This cannot be detected as a EOL style problem because the first
 #' # line ends as expected with \n
-#' styler:::parse_safely("a + 3 -4 -> x\nx + 2\r\n glück + 1")
+#' try(styler:::parse_safely("a + 3 -4 -> x\nx + 2\r\n glück + 1"))
 #' }
 #' styler:::parse_safely("a + 3 -4 -> \n glück + 1")
 parse_safely <- function(text, ...) {

--- a/R/rules-line-breaks.R
+++ b/R/rules-line-breaks.R
@@ -10,7 +10,7 @@
 #'   line trigger.
 #' @keywords internal
 #' @examples
-#' \dontrun{
+#' if (FALSE) {
 #' tryCatch(
 #'   {
 #'     f(8)

--- a/R/rules-line-breaks.R
+++ b/R/rules-line-breaks.R
@@ -11,47 +11,47 @@
 #' @keywords internal
 #' @examples
 #' if (FALSE) {
-#' tryCatch(
-#'   {
-#'     f(8)
-#'   },
-#'   error = function(e) NULL
-#' )
-#' # last-argument case
-#' testthat("braces braces are cool", {
-#'   code(to = execute)
-#' })
-#' call2(
-#'   x = 2, {
+#'   tryCatch(
+#'     {
+#'       f(8)
+#'     },
+#'     error = function(e) NULL
+#'   )
+#'   # last-argument case
+#'   testthat("braces braces are cool", {
 #'     code(to = execute)
-#'   },
-#'   c = {
-#'     # this is the named case
-#'     g(x = 7)
-#'   }
-#' )
-#' tryGugus(
-#'   {
-#'     g5(k = na)
-#'   },
-#'   a + b # line break also here because
-#'   # preceded by brace expression
-#' )
+#'   })
+#'   call2(
+#'     x = 2, {
+#'       code(to = execute)
+#'     },
+#'     c = {
+#'       # this is the named case
+#'       g(x = 7)
+#'     }
+#'   )
+#'   tryGugus(
+#'     {
+#'       g5(k = na)
+#'     },
+#'     a + b # line break also here because
+#'     # preceded by brace expression
+#'   )
 #'
-#' # brace expressions go on new line if part of a pipe, in function call...
-#' c(
+#'   # brace expressions go on new line if part of a pipe, in function call...
+#'   c(
+#'     data %>%
+#'       filter(bar) %>%
+#'       {
+#'         cor(.$col1, .$col2, use = "complete.obs")
+#'       }
+#'   )
+#'   # ... or outside
 #'   data %>%
 #'     filter(bar) %>%
 #'     {
 #'       cor(.$col1, .$col2, use = "complete.obs")
 #'     }
-#' )
-#' # ... or outside
-#' data %>%
-#'   filter(bar) %>%
-#'   {
-#'     cor(.$col1, .$col2, use = "complete.obs")
-#'   }
 #' }
 set_line_break_before_curly_opening <- function(pd) {
   line_break_to_set_idx <- which(

--- a/R/set-assert-args.R
+++ b/R/set-assert-args.R
@@ -56,9 +56,7 @@ assert_transformers <- function(transformers) {
 #'   standard format.
 #' @examples
 #' styler:::set_and_assert_arg_filetype("rMd")
-#' \dontrun{
 #' try(styler:::set_and_assert_arg_filetype("xyz"))
-#' }
 #' @keywords internal
 set_and_assert_arg_filetype <- function(filetype) {
   without_dot <- gsub("^\\.", "", tolower(filetype))

--- a/R/set-assert-args.R
+++ b/R/set-assert-args.R
@@ -57,7 +57,7 @@ assert_transformers <- function(transformers) {
 #' @examples
 #' styler:::set_and_assert_arg_filetype("rMd")
 #' \dontrun{
-#' styler:::set_and_assert_arg_filetype("xyz")
+#' try(styler:::set_and_assert_arg_filetype("xyz"))
 #' }
 #' @keywords internal
 set_and_assert_arg_filetype <- function(filetype) {

--- a/R/transform-files.R
+++ b/R/transform-files.R
@@ -398,7 +398,7 @@ parse_tree_must_be_identical <- function(transformers) {
 #' styler:::verify_roundtrip("a+1", "a + 1")
 #' styler:::verify_roundtrip("a+1", "a + 1 # comments are dropped")
 #' \dontrun{
-#' styler:::verify_roundtrip("a+1", "b - 3")
+#' try(styler:::verify_roundtrip("a+1", "b - 3"))
 #' }
 #' @keywords internal
 verify_roundtrip <- function(old_text, new_text, parsable_only = FALSE) {

--- a/R/transform-files.R
+++ b/R/transform-files.R
@@ -397,9 +397,7 @@ parse_tree_must_be_identical <- function(transformers) {
 #' @examples
 #' styler:::verify_roundtrip("a+1", "a + 1")
 #' styler:::verify_roundtrip("a+1", "a + 1 # comments are dropped")
-#' \dontrun{
 #' try(styler:::verify_roundtrip("a+1", "b - 3"))
-#' }
 #' @keywords internal
 verify_roundtrip <- function(old_text, new_text, parsable_only = FALSE) {
   if (parsable_only) {

--- a/R/ui-styling.R
+++ b/R/ui-styling.R
@@ -50,20 +50,20 @@
 #' @family stylers
 #' @examples
 #' if (FALSE) {
-#' # the following is identical (because of ... and defaults)
-#' # but the first is most convenient:
-#' style_pkg(strict = TRUE)
-#' style_pkg(style = tidyverse_style, strict = TRUE)
-#' style_pkg(transformers = tidyverse_style(strict = TRUE))
+#'   # the following is identical (because of ... and defaults)
+#'   # but the first is most convenient:
+#'   style_pkg(strict = TRUE)
+#'   style_pkg(style = tidyverse_style, strict = TRUE)
+#'   style_pkg(transformers = tidyverse_style(strict = TRUE))
 #'
-#' # more options from `tidyverse_style()`
-#' style_pkg(
-#'   scope = "line_breaks",
-#'   math_token_spacing = specify_math_token_spacing(zero = "'+'")
-#' )
+#'   # more options from `tidyverse_style()`
+#'   style_pkg(
+#'     scope = "line_breaks",
+#'     math_token_spacing = specify_math_token_spacing(zero = "'+'")
+#'   )
 #'
-#' # don't write back and fail if input is not already styled
-#' style_pkg("/path/to/pkg/", dry = "fail")
+#'   # don't write back and fail if input is not already styled
+#'   style_pkg("/path/to/pkg/", dry = "fail")
 #' }
 #' @export
 style_pkg <- function(pkg = ".",
@@ -237,13 +237,13 @@ style_text <- function(text,
 #' @family stylers
 #' @examples
 #' if (FALSE) {
-#' style_dir("path/to/dir", filetype = c("rmd", ".R"))
+#'   style_dir("path/to/dir", filetype = c("rmd", ".R"))
 #'
-#' # the following is identical (because of ... and defaults)
-#' # but the first is most convenient:
-#' style_dir(strict = TRUE)
-#' style_dir(style = tidyverse_style, strict = TRUE)
-#' style_dir(transformers = tidyverse_style(strict = TRUE))
+#'   # the following is identical (because of ... and defaults)
+#'   # but the first is most convenient:
+#'   style_dir(strict = TRUE)
+#'   style_dir(style = tidyverse_style, strict = TRUE)
+#'   style_dir(transformers = tidyverse_style(strict = TRUE))
 #' }
 #' @export
 style_dir <- function(path = ".",

--- a/R/ui-styling.R
+++ b/R/ui-styling.R
@@ -49,7 +49,7 @@
 #' @inheritSection transform_files Value
 #' @family stylers
 #' @examples
-#' \dontrun{
+#' if (FALSE) {
 #' # the following is identical (because of ... and defaults)
 #' # but the first is most convenient:
 #' style_pkg(strict = TRUE)
@@ -236,7 +236,7 @@ style_text <- function(text,
 #' @inheritSection style_pkg Round trip validation
 #' @family stylers
 #' @examples
-#' \dontrun{
+#' if (FALSE) {
 #' style_dir("path/to/dir", filetype = c("rmd", ".R"))
 #'
 #' # the following is identical (because of ... and defaults)

--- a/man/parse_safely.Rd
+++ b/man/parse_safely.Rd
@@ -19,10 +19,10 @@ already.
 }
 \examples{
 \dontrun{
-styler:::parse_safely("a + 3 -4 -> x\r\n glück + 1")
+try(styler:::parse_safely("a + 3 -4 -> x\r\n glück + 1"))
 # This cannot be detected as a EOL style problem because the first
 # line ends as expected with \n
-styler:::parse_safely("a + 3 -4 -> x\nx + 2\r\n glück + 1")
+try(styler:::parse_safely("a + 3 -4 -> x\nx + 2\r\n glück + 1"))
 }
 styler:::parse_safely("a + 3 -4 -> \n glück + 1")
 }

--- a/man/parse_safely.Rd
+++ b/man/parse_safely.Rd
@@ -18,12 +18,11 @@ that we can only detect wrong EOL style if it occurs on the first line
 already.
 }
 \examples{
-\dontrun{
 try(styler:::parse_safely("a + 3 -4 -> x\r\n glück + 1"))
 # This cannot be detected as a EOL style problem because the first
 # line ends as expected with \n
 try(styler:::parse_safely("a + 3 -4 -> x\nx + 2\r\n glück + 1"))
-}
+
 styler:::parse_safely("a + 3 -4 -> \n glück + 1")
 }
 \keyword{internal}

--- a/man/set_and_assert_arg_filetype.Rd
+++ b/man/set_and_assert_arg_filetype.Rd
@@ -17,7 +17,7 @@ processing.
 \examples{
 styler:::set_and_assert_arg_filetype("rMd")
 \dontrun{
-styler:::set_and_assert_arg_filetype("xyz")
+try(styler:::set_and_assert_arg_filetype("xyz"))
 }
 }
 \keyword{internal}

--- a/man/set_and_assert_arg_filetype.Rd
+++ b/man/set_and_assert_arg_filetype.Rd
@@ -16,8 +16,6 @@ processing.
 }
 \examples{
 styler:::set_and_assert_arg_filetype("rMd")
-\dontrun{
 try(styler:::set_and_assert_arg_filetype("xyz"))
-}
 }
 \keyword{internal}

--- a/man/set_line_break_before_curly_opening.Rd
+++ b/man/set_line_break_before_curly_opening.Rd
@@ -20,47 +20,47 @@ line trigger.
 }
 \examples{
 if (FALSE) {
-tryCatch(
-  {
-    f(8)
-  },
-  error = function(e) NULL
-)
-# last-argument case
-testthat("braces braces are cool", {
-  code(to = execute)
-})
-call2(
-  x = 2, {
+  tryCatch(
+    {
+      f(8)
+    },
+    error = function(e) NULL
+  )
+  # last-argument case
+  testthat("braces braces are cool", {
     code(to = execute)
-  },
-  c = {
-    # this is the named case
-    g(x = 7)
-  }
-)
-tryGugus(
-  {
-    g5(k = na)
-  },
-  a + b # line break also here because
-  # preceded by brace expression
-)
+  })
+  call2(
+    x = 2, {
+      code(to = execute)
+    },
+    c = {
+      # this is the named case
+      g(x = 7)
+    }
+  )
+  tryGugus(
+    {
+      g5(k = na)
+    },
+    a + b # line break also here because
+    # preceded by brace expression
+  )
 
-# brace expressions go on new line if part of a pipe, in function call...
-c(
+  # brace expressions go on new line if part of a pipe, in function call...
+  c(
+    data \%>\%
+      filter(bar) \%>\%
+      {
+        cor(.$col1, .$col2, use = "complete.obs")
+      }
+  )
+  # ... or outside
   data \%>\%
     filter(bar) \%>\%
     {
       cor(.$col1, .$col2, use = "complete.obs")
     }
-)
-# ... or outside
-data \%>\%
-  filter(bar) \%>\%
-  {
-    cor(.$col1, .$col2, use = "complete.obs")
-  }
 }
 }
 \keyword{internal}

--- a/man/set_line_break_before_curly_opening.Rd
+++ b/man/set_line_break_before_curly_opening.Rd
@@ -19,7 +19,7 @@ line trigger.
 }
 }
 \examples{
-\dontrun{
+if (FALSE) {
 tryCatch(
   {
     f(8)

--- a/man/style_dir.Rd
+++ b/man/style_dir.Rd
@@ -112,13 +112,13 @@ See section 'Warning' for a good strategy to apply styling safely.
 
 \examples{
 if (FALSE) {
-style_dir("path/to/dir", filetype = c("rmd", ".R"))
+  style_dir("path/to/dir", filetype = c("rmd", ".R"))
 
-# the following is identical (because of ... and defaults)
-# but the first is most convenient:
-style_dir(strict = TRUE)
-style_dir(style = tidyverse_style, strict = TRUE)
-style_dir(transformers = tidyverse_style(strict = TRUE))
+  # the following is identical (because of ... and defaults)
+  # but the first is most convenient:
+  style_dir(strict = TRUE)
+  style_dir(style = tidyverse_style, strict = TRUE)
+  style_dir(transformers = tidyverse_style(strict = TRUE))
 }
 }
 \seealso{

--- a/man/style_dir.Rd
+++ b/man/style_dir.Rd
@@ -111,7 +111,7 @@ See section 'Warning' for a good strategy to apply styling safely.
 }
 
 \examples{
-\dontrun{
+if (FALSE) {
 style_dir("path/to/dir", filetype = c("rmd", ".R"))
 
 # the following is identical (because of ... and defaults)

--- a/man/style_pkg.Rd
+++ b/man/style_pkg.Rd
@@ -109,20 +109,20 @@ styling whether or not it was actually changed (or would be changed when
 
 \examples{
 if (FALSE) {
-# the following is identical (because of ... and defaults)
-# but the first is most convenient:
-style_pkg(strict = TRUE)
-style_pkg(style = tidyverse_style, strict = TRUE)
-style_pkg(transformers = tidyverse_style(strict = TRUE))
+  # the following is identical (because of ... and defaults)
+  # but the first is most convenient:
+  style_pkg(strict = TRUE)
+  style_pkg(style = tidyverse_style, strict = TRUE)
+  style_pkg(transformers = tidyverse_style(strict = TRUE))
 
-# more options from `tidyverse_style()`
-style_pkg(
-  scope = "line_breaks",
-  math_token_spacing = specify_math_token_spacing(zero = "'+'")
-)
+  # more options from `tidyverse_style()`
+  style_pkg(
+    scope = "line_breaks",
+    math_token_spacing = specify_math_token_spacing(zero = "'+'")
+  )
 
-# don't write back and fail if input is not already styled
-style_pkg("/path/to/pkg/", dry = "fail")
+  # don't write back and fail if input is not already styled
+  style_pkg("/path/to/pkg/", dry = "fail")
 }
 }
 \seealso{

--- a/man/style_pkg.Rd
+++ b/man/style_pkg.Rd
@@ -108,7 +108,7 @@ styling whether or not it was actually changed (or would be changed when
 }
 
 \examples{
-\dontrun{
+if (FALSE) {
 # the following is identical (because of ... and defaults)
 # but the first is most convenient:
 style_pkg(strict = TRUE)

--- a/man/verify_roundtrip.Rd
+++ b/man/verify_roundtrip.Rd
@@ -30,8 +30,6 @@ scope.
 \examples{
 styler:::verify_roundtrip("a+1", "a + 1")
 styler:::verify_roundtrip("a+1", "a + 1 # comments are dropped")
-\dontrun{
 try(styler:::verify_roundtrip("a+1", "b - 3"))
-}
 }
 \keyword{internal}

--- a/man/verify_roundtrip.Rd
+++ b/man/verify_roundtrip.Rd
@@ -31,7 +31,7 @@ scope.
 styler:::verify_roundtrip("a+1", "a + 1")
 styler:::verify_roundtrip("a+1", "a + 1 # comments are dropped")
 \dontrun{
-styler:::verify_roundtrip("a+1", "b - 3")
+try(styler:::verify_roundtrip("a+1", "b - 3"))
 }
 }
 \keyword{internal}


### PR DESCRIPTION
`\donttest` examples are run in [an additional check](https://www.stats.ox.ac.uk/pub/bdr/donttest/) by BDR, and probably `\dontrun` examples are also run in some other checks. 

Therefore, making sure all examples run successfully (or are never run if they are just for illustrative purposes) is a good preventive practice in general. 

This PR does that and also adds a workflow to catch such failures in the future.