### PR TITLE
no pkgdown pre-commit action with GitHub Actions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -55,3 +55,4 @@ jobs:
           branch: ${{ github.ref }}
     env:
       RENV_CONFIG_CACHE_ENABLED: FALSE
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -36,6 +36,8 @@ jobs:
           architecture: "x64"
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
+        env: 
+          SKIP: pkgdown
       - name: Commit files
         if: failure() && startsWith(github.ref, 'refs/heads')
         run: |


### PR DESCRIPTION
We already have the pkgdown action. This should be added to the template in lorenzwalthert/precommit.