### PR TITLE
add `qmd` as supported value to `filetype` parameter

### DIFF
--- a/R/ui-styling.R
+++ b/R/ui-styling.R
@@ -87,9 +87,10 @@ style_pkg <- function(pkg = ".",
 #' Prettify a package
 #'
 #' @param filetype Vector of file extensions indicating which file types should
-#'   be styled. Case is ignored, and the `.` is optional, e.g.
-#'   `c(".R", ".Rmd")`, or `c("r", "rmd")`. Supported values (after
-#'   standardization) are: "r", "rprofile", "rmd", "rmarkdown", "rnw". Rmarkdown is treated as Rmd.
+#'   be styled. Case is ignored, and the `.` is optional, e.g. `c(".R",
+#'   ".Rmd")`, or `c("r", "rmd")`. Supported values (after standardization) are:
+#'   "r", "rprofile", "rmd", "rmarkdown", "rnw", "qmd". Rmarkdown is treated as
+#'   Rmd.
 #' @param exclude_files Character vector with paths to files that should be
 #'   excluded from styling.
 #' @param exclude_dirs Character vector with directories to exclude

--- a/man/prettify_any.Rd
+++ b/man/prettify_any.Rd
@@ -21,9 +21,9 @@ conveniently constructed via the \code{style} argument and \code{...}. See
 'Examples'.}
 
 \item{filetype}{Vector of file extensions indicating which file types should
-be styled. Case is ignored, and the \code{.} is optional, e.g.
-\code{c(".R", ".Rmd")}, or \code{c("r", "rmd")}. Supported values (after
-standardization) are: "r", "rprofile", "rmd", "rmarkdown", "rnw". Rmarkdown is treated as Rmd.}
+be styled. Case is ignored, and the \code{.} is optional, e.g. \code{c(".R", ".Rmd")}, or \code{c("r", "rmd")}. Supported values (after standardization) are:
+"r", "rprofile", "rmd", "rmarkdown", "rnw", "qmd". Rmarkdown is treated as
+Rmd.}
 
 \item{recursive}{A logical value indicating whether or not files in
 subdirectories should be styled as well.}

--- a/man/prettify_pkg.Rd
+++ b/man/prettify_pkg.Rd
@@ -19,9 +19,9 @@ prettify_pkg(
 parse tables.}
 
 \item{filetype}{Vector of file extensions indicating which file types should
-be styled. Case is ignored, and the \code{.} is optional, e.g.
-\code{c(".R", ".Rmd")}, or \code{c("r", "rmd")}. Supported values (after
-standardization) are: "r", "rprofile", "rmd", "rmarkdown", "rnw". Rmarkdown is treated as Rmd.}
+be styled. Case is ignored, and the \code{.} is optional, e.g. \code{c(".R", ".Rmd")}, or \code{c("r", "rmd")}. Supported values (after standardization) are:
+"r", "rprofile", "rmd", "rmarkdown", "rnw", "qmd". Rmarkdown is treated as
+Rmd.}
 
 \item{exclude_files}{Character vector with paths to files that should be
 excluded from styling.}

--- a/man/style_dir.Rd
+++ b/man/style_dir.Rd
@@ -34,9 +34,9 @@ conveniently constructed via the \code{style} argument and \code{...}. See
 'Examples'.}
 
 \item{filetype}{Vector of file extensions indicating which file types should
-be styled. Case is ignored, and the \code{.} is optional, e.g.
-\code{c(".R", ".Rmd")}, or \code{c("r", "rmd")}. Supported values (after
-standardization) are: "r", "rprofile", "rmd", "rmarkdown", "rnw". Rmarkdown is treated as Rmd.}
+be styled. Case is ignored, and the \code{.} is optional, e.g. \code{c(".R", ".Rmd")}, or \code{c("r", "rmd")}. Supported values (after standardization) are:
+"r", "rprofile", "rmd", "rmarkdown", "rnw", "qmd". Rmarkdown is treated as
+Rmd.}
 
 \item{recursive}{A logical value indicating whether or not files in
 sub directories of \code{path} should be styled as well.}

--- a/man/style_pkg.Rd
+++ b/man/style_pkg.Rd
@@ -33,9 +33,9 @@ conveniently constructed via the \code{style} argument and \code{...}. See
 'Examples'.}
 
 \item{filetype}{Vector of file extensions indicating which file types should
-be styled. Case is ignored, and the \code{.} is optional, e.g.
-\code{c(".R", ".Rmd")}, or \code{c("r", "rmd")}. Supported values (after
-standardization) are: "r", "rprofile", "rmd", "rmarkdown", "rnw". Rmarkdown is treated as Rmd.}
+be styled. Case is ignored, and the \code{.} is optional, e.g. \code{c(".R", ".Rmd")}, or \code{c("r", "rmd")}. Supported values (after standardization) are:
+"r", "rprofile", "rmd", "rmarkdown", "rnw", "qmd". Rmarkdown is treated as
+Rmd.}
 
 \item{exclude_files}{Character vector with paths to files that should be
 excluded from styling.}


### PR DESCRIPTION
"qmd" was missing as a supported value from the filetype parameter docs. 

I did not `roxygenise()`, yet. 