### PR TITLE
Bump benchmark config

### DIFF
--- a/touchstone/config.json
+++ b/touchstone/config.json
@@ -1,7 +1,7 @@
 {
   "os": "ubuntu-latest",
   "r": "4.2",
-  "rspm": "https://packagemanager.rstudio.com/all/__linux__/focal/2022-08-01",
+  "rspm": "https://packagemanager.rstudio.com/all/__linux__/focal/2023-03-01",
   "benchmarking_repo": "lorenzwalthert/here",
   "benchmarking_ref": "bf0167746da7fe4fb156082bad93c9e5cd3386bd",
   "benchmarking_path": "touchstone/sources/here",


### PR DESCRIPTION
@IndrajeetPatil Seems like `try_fetch()` got a lot faster recently. When I made a benchmark run, it was much faster than `with_handlers()`:
``` r
library(rlang)
bench::mark(
  rlang::with_handlers({}, error = function(...) NULL),
  rlang::try_fetch({}, error = function(...) NULL),
)
#> Warning: `with_handlers()` is deprecated as of rlang 1.0.0.
#> ℹ Please use `tryCatch()`, `withCallingHandlers()`, or `try_fetch()`.
#> This warning is displayed once every 8 hours.
#> # A tibble: 2 × 6
#>   expression                                                 min  median itr/s…¹
#>   <bch:expr>                                            <bch:tm> <bch:t>   <dbl>
#> 1 rlang::with_handlers({ }, error = function(...) NULL)   6.37ms  6.47ms    152.
#> 2 rlang::try_fetch({ }, error = function(...) NULL)      10.75µs 11.62µs  84532.
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>, and abbreviated
#> #   variable name ¹​`itr/sec`
```

<sup>Created on 2023-04-04 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


I am bumping the benchmarking deps here, let's see what they bring and then, you can rebase #1103 on main to see if the problem persists.