### PR TITLE
tweak width of output

### DIFF
--- a/R/transform-files.R
+++ b/R/transform-files.R
@@ -54,7 +54,7 @@ transform_file <- function(path,
                            ...,
                            dry) {
   char_after_path <- nchar(message_before) + nchar(path) + 1L
-  max_char_after_message_path <- nchar(message_before) + max_char_path + 1L
+  max_char_after_message_path <- nchar(message_before) + max_char_path
   n_spaces_before_message_after <-
     max_char_after_message_path - char_after_path
   if (!getOption("styler.quiet", FALSE)) {

--- a/tests/testthat/_snaps/public_api-1.md
+++ b/tests/testthat/_snaps/public_api-1.md
@@ -45,3 +45,38 @@
       ----------------------------------------
       Please review the changes carefully!
 
+# messages have the correct width
+
+    Code
+      styled <- style_pkg(testthat_file("public-api", "xyzpackage"))
+    Output
+      Styling  3  files:
+       R/hello-world.R                  v 
+       tests/testthat.R                 v 
+       tests/testthat/test-package-xyz.R v 
+      ----------------------------------------
+      Status	Count	Legend 
+      v 	3	File unchanged.
+      i 	0	File changed.
+      x 	0	Styling threw an error.
+      ----------------------------------------
+
+---
+
+    Code
+      styled <- style_pkg(
+        testthat_file(
+          "public-api",
+          "xyzpackage"))
+    Output
+      Styling  3  files:
+       R/hello-world.R         v 
+       tests/testthat.R        v 
+       tests/testthat/test-package-xyz.R v 
+      ----------------------------------------
+      Status	Count	Legend 
+      v 	3	File unchanged.
+      i 	0	File changed.
+      x 	0	Styling threw an error.
+      ----------------------------------------
+

--- a/tests/testthat/test-public_api-1.R
+++ b/tests/testthat/test-public_api-1.R
@@ -131,6 +131,16 @@ test_that("messages (via cat()) of style_file are correct", {
   }
 })
 
+test_that("messages have the correct width", {
+  expect_snapshot(
+    styled <- style_pkg(testthat_file("public-api", "xyzpackage"))
+  )
+  withr::local_options(width = 24)
+  expect_snapshot({
+    styled <- style_pkg(testthat_file("public-api", "xyzpackage"))
+  })
+})
+
 test_that("Messages can be suppressed", {
   withr::with_options(
     list(styler.quiet = TRUE),


### PR DESCRIPTION
follow-up to #1187 

The +1 seems to cause rendering issues 
It seems like it was added in https://github.com/r-lib/styler/pull/165

I know that cli exports `cli::ansi_nchar()`, but it will probably slow down a little bit the execution to use this.

![image](https://github.com/r-lib/styler/assets/52606734/6047919c-5450-4590-8d1a-919b5f736abe)

while on main currently, I had
![image](https://github.com/r-lib/styler/assets/52606734/d05e08e5-5889-45e3-8017-bb08a2c3d005)

Sorry I didn't test this more extensively in the first place.
