### PR TITLE
Use Bootstrap 5 template for pkgdown website

### DIFF
--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -1,9 +1,6 @@
 home:
   strip_header: true
 
-template:
-  bootstrap: 5
-
 reference:
   - title: "Styling API"
     desc: >
@@ -45,11 +42,9 @@ reference:
       - print.vertical
 
 template:
+  bootstrap: 5
   params:
     bootswatch: flatly # https://bootswatch.com/flatly/
-    docsearch:
-      api_key: 13580d327d8a7159f83a7cff178d2141
-      index_name: r-lib_styler
 
 authors:
   Kirill Müller:

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -1,6 +1,9 @@
 home:
   strip_header: true
 
+template:
+  bootstrap: 5
+
 reference:
   - title: "Styling API"
     desc: >


### PR DESCRIPTION
BS3 is being [deprecated](https://github.com/r-lib/pkgdown/pull/2545) in pkgdown.

But, even if that were not the case, the website has a lot to gain from this switch, and not much to lose (I recall you not being happy with the search feature). The BS3 look is quite cumbersome (e.g. try reading [this vignette](https://styler.r-lib.org/dev/articles/customizing_styler.html) on mobile browser).