### PR TITLE
Use stable version of `{purrr}`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Depends:
 Imports: 
     cli (>= 3.1.1),
     magrittr (>= 2.0.0),
-    purrr (>= 0.2.3),
+    purrr (>= 1.0.2),
     R.cache (>= 0.15.0),
     rlang (>= 1.0.0),
     rprojroot (>= 1.1),

--- a/R/compat-dplyr.R
+++ b/R/compat-dplyr.R
@@ -51,9 +51,3 @@ left_join <- function(x, y, by) {
 last <- function(x) {
   x[[length(x)]]
 }
-
-map_dfr <- function(.x, .f, ...) {
-  .f <- purrr::as_mapper(.f, ...)
-  res <- map(.x, .f, ...)
-  vec_rbind(!!!res)
-}

--- a/R/compat-dplyr.R
+++ b/R/compat-dplyr.R
@@ -10,12 +10,6 @@ lead <- function(x, n = 1L, default = NA) {
   c(x[-seq_len(n)], rep(default, n))
 }
 
-
-arrange <- function(.data, ...) {
-  ord <- eval(substitute(order(...)), .data, parent.frame())
-  vec_slice(.data, ord)
-}
-
 arrange_pos_id <- function(data) {
   pos_id <- data$pos_id
   if (is.unsorted(pos_id)) {

--- a/R/visit.R
+++ b/R/visit.R
@@ -233,10 +233,11 @@ enrich_terminals <- function(flattened_pd, use_raw_indention = FALSE) {
   groups <- flattened_pd$line1
   split_pd <- vec_split(flattened_pd, groups)[[2L]]
   flattened_pd <- split_pd %>%
-    map_dfr(function(.x) {
+    purrr::map(function(.x) {
       .x$col2 <- cumsum(.x$nchar + .x$lag_spaces)
       .x
-    })
+    }) %>%
+    purrr::list_rbind()
   flattened_pd$col1 <- flattened_pd$col2 - flattened_pd$nchar
   flattened_pd
 }


### PR DESCRIPTION
Benchmarks:

- `map_dfr()` vs `map() + list_rbind()`

``` r
internal_map_dfr <- function(.x, .f, ...) {
  .f <- purrr::as_mapper(.f, ...)
  res <- purrr::map(.x, .f, ...)
  vctrs::vec_rbind(!!!res)
}

x <- list(
  a = data.frame(x = rnorm(1e6)),
  b = data.frame(y = rnorm(1e6))
)

bench::mark(
  internal_map_dfr(x, ~ .x),
  purrr::map(x, ~ .x) |> purrr::list_rbind()
)
#> # A tibble: 2 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                          <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 internal_map_dfr(x, ~.x)            4.93ms 5.08ms      168.    46.3MB     364.
#> 2 purrr::list_rbind(purrr::map(x, ~.… 4.81ms    5ms      199.    45.8MB     388.
```

<sup>Created on 2024-05-23 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>