### PR TITLE
Better handling of nested multi-line function definitions, e.g. R6

### DIFF
--- a/R/rules-indention.R
+++ b/R/rules-indention.R
@@ -58,12 +58,20 @@ is_single_indent_function_declaration <- function(pd, indent_by = 2L) {
   if (length(formals) == 0L) return(FALSE)
 
   first_formal_idx <- formals[1L]
-  if (!any(pd$lag_newlines[seq2(idx_paren_open + 1L, first_formal_idx)] > 0L)) {
-    return(FALSE)
+  if (any(pd$lag_newlines[seq2(idx_paren_open + 1L, first_formal_idx)] > 0L)) {
+    return(pd$lag_newlines[idx_paren_close] > 0L || pd$spaces[first_formal_idx - 1L] <= 2L * indent_by)
   }
 
-  pd$lag_newlines[idx_paren_close] > 0L ||
-    pd$spaces[first_formal_idx - 1L] <= 2L * indent_by
+  formals_nl <- which(
+    pd$token %in% c("SYMBOL_FORMALS", "SYMBOL_SUB") &
+      pd$lag_newlines > 0L &
+      row_idx > idx_paren_open &
+      row_idx < idx_paren_close
+  )
+  if (length(formals_nl) == 0L) return(FALSE)
+
+  first_nl_formal <- formals_nl[1L]
+  pd$spaces[first_nl_formal - 1L] <= 2L * indent_by
 }
 
 

--- a/R/rules-indention.R
+++ b/R/rules-indention.R
@@ -41,16 +41,24 @@ unindent_function_declaration <- function(pd, indent_by = 2L) {
 #' @inheritParams tidyverse_style
 #' @keywords internal
 is_single_indent_function_declaration <- function(pd, indent_by = 2L) {
-  head_pd <- vec_slice(pd, -nrow(pd))
-  line_break_in_header <- which(head_pd$lag_newlines > 0L & head_pd$token == "SYMBOL_FORMALS")
-  if (length(line_break_in_header) > 0L) {
-    # indent results from applying the rules, spaces is the initial spaces
-    # (which is indention if a newline is ahead)
-    # The 2L factor is kept to convert double indent to single indent
-    pd$spaces[line_break_in_header[1L] - 1L] <= 2L * indent_by
-  } else {
-    FALSE
+  idx_paren_open <- which(pd$token == "'('")[1L]
+  idx_paren_close <- which(pd$token == "')'")[1L]
+  if (is.na(idx_paren_open) || is.na(idx_paren_close)) return(FALSE)
+
+  formals <- which(
+    pd$token %in% c("SYMBOL_FORMALS", "SYMBOL_SUB") &
+      seq_len(nrow(pd)) > idx_paren_open &
+      seq_len(nrow(pd)) < idx_paren_close
+  )
+  if (length(formals) == 0L) return(FALSE)
+
+  first_formal_idx <- formals[1L]
+  if (!any(pd$lag_newlines[seq2(idx_paren_open + 1L, first_formal_idx)] > 0L)) {
+    return(FALSE)
   }
+
+  pd$lag_newlines[idx_paren_close] > 0L ||
+    pd$spaces[first_formal_idx - 1L] <= 2L * indent_by
 }
 
 

--- a/R/rules-indention.R
+++ b/R/rules-indention.R
@@ -32,15 +32,15 @@ unindent_function_declaration <- function(pd, indent_by = 2L) {
   pd
 }
 
-#' Is the function declaration authored with single indentation?
+#' Is the function declaration single indented?
 #'
-#' Assumes you already checked if it's a function declaration with
-#' `is_function_declaration`. It returns `TRUE` if the declaration is authored
-#' with single indentation (where the first argument starts on a new line and
-#' the closing parenthesis `)` starts on a new line, or where arguments on new
-#' lines are indented by `<= 2 * indent_by` spaces). It returns `FALSE` if
-#' authored with hanging indentation (where arguments share the line with
-#' `function(` or `)` and are aligned).
+#' Assumes you already checked if it's a function with
+#' `is_function_declaration`. "single indented" means the formals are on the
+#' line after `function(` and indented one further level, and the closing `)`
+#' is also on its own line. The alternative compliant style within the style
+#' guide is "hanging indented" where formals share the line with `function(`,
+#' any subsequent lines of formals are indented relative to that `(`, and
+#' the closing `)` shares a line with the last formal argument.
 #' @param pd A parse table.
 #' @inheritParams tidyverse_style
 #' @keywords internal

--- a/R/rules-indention.R
+++ b/R/rules-indention.R
@@ -47,17 +47,18 @@ unindent_function_declaration <- function(pd, indent_by = 2L) {
 is_single_indent_function_declaration <- function(pd, indent_by = 2L) {
   idx_paren_open <- which(pd$token == "'('")[1L]
   idx_paren_close <- which(pd$token == "')'")[1L]
-  if (is.na(idx_paren_open) || is.na(idx_paren_close)) return(FALSE)
 
   row_idx <- seq_len(nrow(pd))
-  formals <- which(
-    pd$token %in% c("SYMBOL_FORMALS", "SYMBOL_SUB") &
+  is_formal <- (
+    pd$token == "SYMBOL_FORMALS" &
       row_idx > idx_paren_open &
       row_idx < idx_paren_close
   )
-  if (length(formals) == 0L) return(FALSE)
+  if (!any(is_formal)) {
+    return(FALSE)
+  }
 
-  first_formal_idx <- formals[1L]
+  first_formal_idx <- which(is_formal)[1L]
   # If authored with single indentation (first argument on new line),
   # return TRUE unless closing parenthesis shares the line (indicating hanging indentation).
   if (any(pd$lag_newlines[seq2(idx_paren_open + 1L, first_formal_idx)] > 0L)) {
@@ -66,18 +67,14 @@ is_single_indent_function_declaration <- function(pd, indent_by = 2L) {
 
   # If first argument shares line with '(', check if subsequent arguments on new lines
   # have single indentation (<= 4 spaces) vs. hanging indentation (> 4 spaces).
-  formals_nl <- which(
-    pd$token %in% c("SYMBOL_FORMALS", "SYMBOL_SUB") &
-      pd$lag_newlines > 0L &
-      row_idx > idx_paren_open &
-      row_idx < idx_paren_close
-  )
-  if (length(formals_nl) == 0L) return(FALSE)
+  is_formal_nl <- is_formal & pd$lag_newlines > 0L
+  if (!any(is_formal_nl)) {
+    return(FALSE)
+  }
 
-  first_nl_formal <- formals_nl[1L]
+  first_nl_formal <- which(is_formal_nl)[1L]
   pd$spaces[first_nl_formal - 1L] <= 2L * indent_by
 }
-
 
 
 #' @describeIn update_indention Indents *all* tokens after `token` - including

--- a/R/rules-indention.R
+++ b/R/rules-indention.R
@@ -45,10 +45,11 @@ is_single_indent_function_declaration <- function(pd, indent_by = 2L) {
   idx_paren_close <- which(pd$token == "')'")[1L]
   if (is.na(idx_paren_open) || is.na(idx_paren_close)) return(FALSE)
 
+  row_idx <- seq_len(nrow(pd))
   formals <- which(
     pd$token %in% c("SYMBOL_FORMALS", "SYMBOL_SUB") &
-      seq_len(nrow(pd)) > idx_paren_open &
-      seq_len(nrow(pd)) < idx_paren_close
+      row_idx > idx_paren_open &
+      row_idx < idx_paren_close
   )
   if (length(formals) == 0L) return(FALSE)
 

--- a/R/rules-indention.R
+++ b/R/rules-indention.R
@@ -32,15 +32,15 @@ unindent_function_declaration <- function(pd, indent_by = 2L) {
   pd
 }
 
-#' Is the function declaration authored with standard single/double indentation?
+#' Is the function declaration authored with single indentation?
 #'
 #' Assumes you already checked if it's a function declaration with
-#' `is_function_declaration`. It returns `TRUE` if the first formal argument
-#' starts on a new line AND either the closing parenthesis `)` also starts on a
-#' new line or the first argument is indented by standard single/double
-#' indentation (`<= 2 * indent_by` spaces). This robustly identifies standard
-#' multi-line headers while correctly returning `FALSE` for aligned/hanging
-#' indents (where arguments start on the first line or share the line with `)`).
+#' `is_function_declaration`. It returns `TRUE` if the declaration is authored
+#' with single indentation (where the first argument starts on a new line and
+#' the closing parenthesis `)` starts on a new line, or where arguments on new
+#' lines are indented by `<= 2 * indent_by` spaces). It returns `FALSE` if
+#' authored with hanging indentation (where arguments share the line with
+#' `function(` or `)` and are aligned).
 #' @param pd A parse table.
 #' @inheritParams tidyverse_style
 #' @keywords internal
@@ -58,10 +58,14 @@ is_single_indent_function_declaration <- function(pd, indent_by = 2L) {
   if (length(formals) == 0L) return(FALSE)
 
   first_formal_idx <- formals[1L]
+  # If authored with single indentation (first argument on new line),
+  # return TRUE unless closing parenthesis shares the line (indicating hanging indentation).
   if (any(pd$lag_newlines[seq2(idx_paren_open + 1L, first_formal_idx)] > 0L)) {
     return(pd$lag_newlines[idx_paren_close] > 0L || pd$spaces[first_formal_idx - 1L] <= 2L * indent_by)
   }
 
+  # If first argument shares line with '(', check if subsequent arguments on new lines
+  # have single indentation (<= 4 spaces) vs. hanging indentation (> 4 spaces).
   formals_nl <- which(
     pd$token %in% c("SYMBOL_FORMALS", "SYMBOL_SUB") &
       pd$lag_newlines > 0L &

--- a/R/rules-indention.R
+++ b/R/rules-indention.R
@@ -32,11 +32,15 @@ unindent_function_declaration <- function(pd, indent_by = 2L) {
   pd
 }
 
-#' Is the function declaration single indented?
+#' Is the function declaration authored with standard single/double indentation?
 #'
-#' Assumes you already checked if it's a function with
-#' `is_function_declaration`. It is single indented if the first token
-#' after the first line break that is a `"SYMBOL_FORMALS"`.
+#' Assumes you already checked if it's a function declaration with
+#' `is_function_declaration`. It returns `TRUE` if the first formal argument
+#' starts on a new line AND either the closing parenthesis `)` also starts on a
+#' new line or the first argument is indented by standard single/double
+#' indentation (`<= 2 * indent_by` spaces). This robustly identifies standard
+#' multi-line headers while correctly returning `FALSE` for aligned/hanging
+#' indents (where arguments start on the first line or share the line with `)`).
 #' @param pd A parse table.
 #' @inheritParams tidyverse_style
 #' @keywords internal

--- a/man/is_single_indent_function_declaration.Rd
+++ b/man/is_single_indent_function_declaration.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/rules-indention.R
 \name{is_single_indent_function_declaration}
 \alias{is_single_indent_function_declaration}
-\title{Is the function declaration authored with standard single/double indentation?}
+\title{Is the function declaration authored with single indentation?}
 \usage{
 is_single_indent_function_declaration(pd, indent_by = 2L)
 }
@@ -14,11 +14,11 @@ operators such as '('.}
 }
 \description{
 Assumes you already checked if it's a function declaration with
-\code{is_function_declaration}. It returns \code{TRUE} if the first formal argument
-starts on a new line AND either the closing parenthesis \verb{)} also starts on a
-new line or the first argument is indented by standard single/double
-indentation (\verb{<= 2 * indent_by} spaces). This robustly identifies standard
-multi-line headers while correctly returning \code{FALSE} for aligned/hanging
-indents (where arguments start on the first line or share the line with \verb{)}).
+\code{is_function_declaration}. It returns \code{TRUE} if the declaration is authored
+with single indentation (where the first argument starts on a new line and
+the closing parenthesis \verb{)} starts on a new line, or where arguments on new
+lines are indented by \verb{<= 2 * indent_by} spaces). It returns \code{FALSE} if
+authored with hanging indentation (where arguments share the line with
+\verb{function(} or \verb{)} and are aligned).
 }
 \keyword{internal}

--- a/man/is_single_indent_function_declaration.Rd
+++ b/man/is_single_indent_function_declaration.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/rules-indention.R
 \name{is_single_indent_function_declaration}
 \alias{is_single_indent_function_declaration}
-\title{Is the function declaration single indented?}
+\title{Is the function declaration authored with standard single/double indentation?}
 \usage{
 is_single_indent_function_declaration(pd, indent_by = 2L)
 }
@@ -13,8 +13,12 @@ is_single_indent_function_declaration(pd, indent_by = 2L)
 operators such as '('.}
 }
 \description{
-Assumes you already checked if it's a function with
-\code{is_function_declaration}. It is single indented if the first token
-after the first line break that is a \code{"SYMBOL_FORMALS"}.
+Assumes you already checked if it's a function declaration with
+\code{is_function_declaration}. It returns \code{TRUE} if the first formal argument
+starts on a new line AND either the closing parenthesis \verb{)} also starts on a
+new line or the first argument is indented by standard single/double
+indentation (\verb{<= 2 * indent_by} spaces). This robustly identifies standard
+multi-line headers while correctly returning \code{FALSE} for aligned/hanging
+indents (where arguments start on the first line or share the line with \verb{)}).
 }
 \keyword{internal}

--- a/man/is_single_indent_function_declaration.Rd
+++ b/man/is_single_indent_function_declaration.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/rules-indention.R
 \name{is_single_indent_function_declaration}
 \alias{is_single_indent_function_declaration}
-\title{Is the function declaration authored with single indentation?}
+\title{Is the function declaration single indented?}
 \usage{
 is_single_indent_function_declaration(pd, indent_by = 2L)
 }
@@ -13,12 +13,12 @@ is_single_indent_function_declaration(pd, indent_by = 2L)
 operators such as '('.}
 }
 \description{
-Assumes you already checked if it's a function declaration with
-\code{is_function_declaration}. It returns \code{TRUE} if the declaration is authored
-with single indentation (where the first argument starts on a new line and
-the closing parenthesis \verb{)} starts on a new line, or where arguments on new
-lines are indented by \verb{<= 2 * indent_by} spaces). It returns \code{FALSE} if
-authored with hanging indentation (where arguments share the line with
-\verb{function(} or \verb{)} and are aligned).
+Assumes you already checked if it's a function with
+\code{is_function_declaration}. "single indented" means the formals are on the
+line after \verb{function(} and indented one further level, and the closing \verb{)}
+is also on its own line. The alternative compliant style within the style
+guide is "hanging indented" where formals share the line with \verb{function(},
+any subsequent lines of formals are indented relative to that \code{(}, and
+the closing \verb{)} shares a line with the last formal argument.
 }
 \keyword{internal}

--- a/tests/testthat/fun_dec/line_break_fun_dec-in.R
+++ b/tests/testthat/fun_dec/line_break_fun_dec-in.R
@@ -48,7 +48,7 @@ a <- function( #
 }
 
 
-# nested multi-line header
+# nested multi-line header -> single indentation
 list(
   a = function(
     x,
@@ -58,7 +58,7 @@ list(
 )
 
 
-# ambiguous case: closing parenthesis starts on new line (weirdly indented) -> open indent
+# ambiguous case: closing parenthesis starts on new line -> single indentation
 a <- function(
               x,
               y
@@ -67,7 +67,7 @@ a <- function(
 }
 
 
-# ambiguous case: closing parenthesis starts on new line -> open indent
+# ambiguous case: closing parenthesis starts on new line -> single indentation
 a <- function(
               x,
               y
@@ -76,19 +76,19 @@ a <- function(
 }
 
 
-# mixed structure A: first formal on same line, subsequent formal on new line (standard indent <= 4 spaces) -> open multi-line
+# mixed structure A: subsequent formal on new line (<= 4 spaces) -> single indentation
 f <- function(a =
   1,
   b = 2
 ) {}
 
 
-# mixed structure B: first formal on same line, subsequent formal on new line (heavily indented > 4 spaces) AND ')' on same line -> preserve aligned
+# mixed structure B: heavily indented (> 4 spaces) AND ')' on same line -> hanging indentation
 f <- function(a = 1,
               b = 2) {}
 
 
-# mixed structure C: first formal on same line, subsequent formal on new line (heavily indented > 4 spaces) BUT ')' starts on new line -> open multi-line
+# mixed structure C: heavily indented (> 4 spaces) BUT ')' starts on new line -> single indentation
 f <- function(a =
                 1,
               b = 2

--- a/tests/testthat/fun_dec/line_break_fun_dec-in.R
+++ b/tests/testthat/fun_dec/line_break_fun_dec-in.R
@@ -56,3 +56,21 @@ list(
     x - 1
   }
 )
+
+
+# ambiguous case: closing parenthesis starts on new line (weirdly indented) -> open indent
+a <- function(
+              x,
+              y
+               ) {
+  x - 1
+}
+
+
+# ambiguous case: closing parenthesis starts on new line -> open indent
+a <- function(
+              x,
+              y
+) {
+  x - 1
+}

--- a/tests/testthat/fun_dec/line_break_fun_dec-in.R
+++ b/tests/testthat/fun_dec/line_break_fun_dec-in.R
@@ -74,3 +74,22 @@ a <- function(
 ) {
   x - 1
 }
+
+
+# mixed structure A: first formal on same line, subsequent formal on new line (standard indent <= 4 spaces) -> open multi-line
+f <- function(a =
+  1,
+  b = 2
+) {}
+
+
+# mixed structure B: first formal on same line, subsequent formal on new line (heavily indented > 4 spaces) AND ')' on same line -> preserve aligned
+f <- function(a = 1,
+              b = 2) {}
+
+
+# mixed structure C: first formal on same line, subsequent formal on new line (heavily indented > 4 spaces) BUT ')' starts on new line -> open multi-line
+f <- function(a =
+                1,
+              b = 2
+) {}

--- a/tests/testthat/fun_dec/line_break_fun_dec-in.R
+++ b/tests/testthat/fun_dec/line_break_fun_dec-in.R
@@ -46,3 +46,13 @@ a <- function( #
   y) {
   x - 1
 }
+
+
+# nested multi-line header
+list(
+  a = function(
+    x,
+    y) {
+    x - 1
+  }
+)

--- a/tests/testthat/fun_dec/line_break_fun_dec-out.R
+++ b/tests/testthat/fun_dec/line_break_fun_dec-out.R
@@ -48,7 +48,7 @@ a <- function(
 }
 
 
-# nested multi-line header
+# nested multi-line header -> single indentation
 list(
   a = function(
     x,
@@ -59,7 +59,7 @@ list(
 )
 
 
-# ambiguous case: closing parenthesis starts on new line (weirdly indented) -> open indent
+# ambiguous case: closing parenthesis starts on new line -> single indentation
 a <- function(
   x,
   y
@@ -68,7 +68,7 @@ a <- function(
 }
 
 
-# ambiguous case: closing parenthesis starts on new line -> open indent
+# ambiguous case: closing parenthesis starts on new line -> single indentation
 a <- function(
   x,
   y
@@ -77,7 +77,7 @@ a <- function(
 }
 
 
-# mixed structure A: first formal on same line, subsequent formal on new line (standard indent <= 4 spaces) -> open multi-line
+# mixed structure A: subsequent formal on new line (<= 4 spaces) -> single indentation
 f <- function(
   a =
     1,
@@ -85,12 +85,12 @@ f <- function(
 ) {}
 
 
-# mixed structure B: first formal on same line, subsequent formal on new line (heavily indented > 4 spaces) AND ')' on same line -> preserve aligned
+# mixed structure B: heavily indented (> 4 spaces) AND ')' on same line -> hanging indentation
 f <- function(a = 1,
               b = 2) {}
 
 
-# mixed structure C: first formal on same line, subsequent formal on new line (heavily indented > 4 spaces) BUT ')' starts on new line -> open multi-line
+# mixed structure C: heavily indented (> 4 spaces) BUT ')' starts on new line -> single indentation
 f <- function(a =
                 1,
               b = 2) {}

--- a/tests/testthat/fun_dec/line_break_fun_dec-out.R
+++ b/tests/testthat/fun_dec/line_break_fun_dec-out.R
@@ -57,3 +57,21 @@ list(
     x - 1
   }
 )
+
+
+# ambiguous case: closing parenthesis starts on new line (weirdly indented) -> open indent
+a <- function(
+  x,
+  y
+) {
+  x - 1
+}
+
+
+# ambiguous case: closing parenthesis starts on new line -> open indent
+a <- function(
+  x,
+  y
+) {
+  x - 1
+}

--- a/tests/testthat/fun_dec/line_break_fun_dec-out.R
+++ b/tests/testthat/fun_dec/line_break_fun_dec-out.R
@@ -46,3 +46,14 @@ a <- function(
 ) {
   x - 1
 }
+
+
+# nested multi-line header
+list(
+  a = function(
+    x,
+    y
+  ) {
+    x - 1
+  }
+)

--- a/tests/testthat/fun_dec/line_break_fun_dec-out.R
+++ b/tests/testthat/fun_dec/line_break_fun_dec-out.R
@@ -75,3 +75,22 @@ a <- function(
 ) {
   x - 1
 }
+
+
+# mixed structure A: first formal on same line, subsequent formal on new line (standard indent <= 4 spaces) -> open multi-line
+f <- function(
+  a =
+    1,
+  b = 2
+) {}
+
+
+# mixed structure B: first formal on same line, subsequent formal on new line (heavily indented > 4 spaces) AND ')' on same line -> preserve aligned
+f <- function(a = 1,
+              b = 2) {}
+
+
+# mixed structure C: first formal on same line, subsequent formal on new line (heavily indented > 4 spaces) BUT ')' starts on new line -> open multi-line
+f <- function(a =
+                1,
+              b = 2) {}


### PR DESCRIPTION
Closes #1136.

Written by Gemini.

One ambiguous case was the existing test case:

https://github.com/r-lib/styler/blob/290d9934643ba1d7ecd5d0f23ba455c5b3c85858/tests/testthat/fun_dec/line_break_fun_dec-in.R#L38-L42

Here, it's a bit tough to decide whether to style this as hanging or "open". I nudged the rule to select "hanging" here because (1) `x` and `y` are in the columns they would be for "hanging" and (2) the `)` comes on the same line as `y`. See new test cases for more similar situations.